### PR TITLE
Use default profile and improve error handling

### DIFF
--- a/scripts/aws-mfa-session.sh
+++ b/scripts/aws-mfa-session.sh
@@ -11,39 +11,47 @@ fi
 
 # https://stackoverflow.com/questions/9901210/bash-source0-equivalent-in-zsh
 # shellcheck disable=SC2296
-if { [ -z "$1" ] || [ -z "$2" ]; }; then
+if { [ -z "$1" ]; }; then
   echo 2>&1 "Usage: source ${BASH_SOURCE:-${(%):-%x}} <account> <profile>"
   echo 2>&1 "Where <account> is the AWS account number and <profile> is the name"
   echo 2>&1 "of the profile with permanent creds in ~/.aws/credentials."
   return 1
 fi
 
-# Read input into variable
+# Read input for MFA code
 printf >&2 '%s ' 'Enter MFA code:'
 read -r mfa_code
 
+profile="${2:-default}"
 tmpfile=$(mktemp)
 
-echo 2>&1 "Getting session token for profile $2"
+cleanup() {
+  rm "$tmpfile"
+  unset mfa_code
+  unset profile
+  unset tmpfile
+}
 
-if ! aws --profile="$2" sts get-session-token --serial-number \
+echo 2>&1 "Getting session token for profile $profile"
+if ! aws --profile="$profile" sts get-session-token --serial-number \
     "arn:aws:iam::$1:mfa/app" --token-code "$mfa_code" > "$tmpfile"; then
   echo 2>&1 "Error getting session token"
+  cleanup
   return 1
 fi
 
-unset mfa_code
+echo 2>&1 "Setting environment variables for AWS session"
+if AWS_ACCESS_KEY_ID="$(jq -r '.Credentials.AccessKeyId' "$tmpfile")" &&
+    AWS_SECRET_ACCESS_KEY="$(jq -r '.Credentials.SecretAccessKey' "$tmpfile")" &&
+    AWS_SESSION_TOKEN="$(jq -r '.Credentials.SessionToken' "$tmpfile")"; then
+  export AWS_ACCESS_KEY_ID
+  export AWS_SECRET_ACCESS_KEY
+  export AWS_SESSION_TOKEN
+else
+  cleanup
+  return 1
+fi
 
-# Set environment variables
-AWS_ACCESS_KEY_ID="$(jq -r '.Credentials.AccessKeyId' "$tmpfile")"
-AWS_SECRET_ACCESS_KEY="$(jq -r '.Credentials.SecretAccessKey' "$tmpfile")"
-AWS_SESSION_TOKEN="$(jq -r '.Credentials.SessionToken' "$tmpfile")"
-export AWS_ACCESS_KEY_ID
-export AWS_SECRET_ACCESS_KEY
-export AWS_SESSION_TOKEN
+echo 2>&1 "Session initialized for profile $profile"
 
-# Remove temp file
-rm "$tmpfile"
-unset tmpfile
-
-echo 2>&1 "Session initialized for profile $2"
+cleanup

--- a/scripts/aws-mfa-session.sh
+++ b/scripts/aws-mfa-session.sh
@@ -22,7 +22,9 @@ fi
 printf >&2 '%s ' 'Enter MFA code:'
 read -r mfa_code
 
+# Use default profile in ~/.aws/credentials if one is not specified
 profile="${2:-default}"
+
 tmpfile=$(mktemp)
 
 cleanup() {


### PR DESCRIPTION
## 🎫 Ticket

No ticket - quick fix

## 🛠 Changes

Updated the aws-mfa-session script to use the default profile by default, and improved its error handling when, for example, jq is not installed on the machine.

## ℹ️ Context for reviewers

In running the command on a new machine I saw some issues to be addressed.

## ✅ Acceptance Validation

Now runs with expected behavior on my laptop.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.