### PR TITLE
PLT-193 Add paths for push to main

### DIFF
--- a/.github/workflows/github-actions-terraform-apply.yml
+++ b/.github/workflows/github-actions-terraform-apply.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/github-actions-terraform-plan.yml
+      - terraform/services/github-actions/**
   workflow_dispatch: # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-193

## 🛠 Changes

Added paths in the trigger on push to main.

## ℹ️ Context for reviewers

This will constrain the trigger to only run on pushes that include paths relevant to the github actions runner terraform.

## ✅ Acceptance Validation

This should run on merge of this PR to main. We'll monitor future merges to ensure it only runs when needed.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
