### PR TITLE
PLT-193 Trigger on apply, not plan

### DIFF
--- a/.github/workflows/github-actions-terraform-apply.yml
+++ b/.github/workflows/github-actions-terraform-apply.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - .github/workflows/github-actions-terraform-plan.yml
+      - .github/workflows/github-actions-terraform-apply.yml
       - terraform/services/github-actions/**
   workflow_dispatch: # Allow manual trigger
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-193

## 🛠 Changes

Fixed trigger path to point to this apply workflow, not the plan workflow.

## ℹ️ Context for reviewers

Missed this when copying paths over from github-actions-terraform-plan

## ✅ Acceptance Validation

Will monitor on merge.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
