### PR TITLE
PLT-248 Set minimum running time for GitHub Actions runners

### DIFF
--- a/terraform/services/github-actions/main.tf
+++ b/terraform/services/github-actions/main.tf
@@ -81,6 +81,9 @@ module "github-actions" {
     evictionStrategy = "oldest_first"
   }]
 
+  # Set minimum running time to avoid terminating instances before user data is executed
+  minimum_running_time_in_minutes = 10
+
   runner_iam_role_managed_policy_arns  = [aws_iam_policy.runner.arn]
   runner_additional_security_group_ids = [data.aws_security_group.vpn.id]
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-248

## 🛠 Changes

Minimum running time was set on GitHub Actions runners.

## ℹ️ Context for reviewers

The scale-down lambda will sometimes terminate instances before they execute user data. We believe the slow startup is due to network wait on the Splunk forwarder. This is a temporary fix to avoid timing out. Longer term we can avoid needing user data by building our images, and possibly removing the Splunk forwarder from startup since these instances are sending logs to Splunk via cloudwatch.

## ✅ Acceptance Validation

See check for terraform plan. Minimum time raised from 5 to 10 minutes.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
