### PR TITLE
updating github runner instance size

### DIFF
--- a/terraform/services/github-actions/main.tf
+++ b/terraform/services/github-actions/main.tf
@@ -89,6 +89,6 @@ module "github-actions" {
 
   instance_target_capacity_type = "on-demand"
   instance_types = [
-    "t3.medium",
+    "t3.large",
   ]
 }


### PR DESCRIPTION
This is to update the runner size from t3.medium to t3.large due to memory constraints when running jobs.