### PR TITLE
PLT-248 Set boot time on runners

### DIFF
--- a/terraform/services/github-actions/main.tf
+++ b/terraform/services/github-actions/main.tf
@@ -81,8 +81,9 @@ module "github-actions" {
     evictionStrategy = "oldest_first"
   }]
 
-  # Set minimum running time to avoid terminating instances before user data is executed
-  minimum_running_time_in_minutes = 10
+  # Set boot time to avoid terminating instances before user data is executed
+  # Defaults to 5 minutes
+  runner_boot_time_in_minutes = 10
 
   runner_iam_role_managed_policy_arns  = [aws_iam_policy.runner.arn]
   runner_additional_security_group_ids = [data.aws_security_group.vpn.id]


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-248

## 🛠 Changes

Set boot time instead of minimum running time, which should allow for installation of the actions agent before scale-down terminates the instance.

## ℹ️ Context for reviewers

We were still seeing instances terminated at 5 minutes after the change in #24.

## ✅ Acceptance Validation

Will test by running jobs in ab2d-events and runner AMI creation following merge.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
