### PR TITLE
PLT-279 Add terraform for tfstate service

### DIFF
--- a/terraform/services/tfstate/.terraform.lock.hcl
+++ b/terraform/services/tfstate/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.8.0"
+  constraints = "~> 5.8.0"
+  hashes = [
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}

--- a/terraform/services/tfstate/README.md
+++ b/terraform/services/tfstate/README.md
@@ -1,0 +1,14 @@
+# Terraform for initializing tfstate resources
+
+This terraform creates the S3 buckets and DynamoDB table for storing terraform state in AWS.
+
+Do not specify a backend config for the first `terraform init` to use a local tfstate.
+
+    terraform init
+    terraform apply -var="name=bcda-mgmt-tfstate"
+
+Once the resources have been created, uncomment the backend block in versions.tf and reference a backend config:
+
+    terraform init -backend-config=../../backends/bcda-mgmt.s3.tfbackend
+
+The command should prompt to migrate the existing local state to the remote backend.

--- a/terraform/services/tfstate/main.tf
+++ b/terraform/services/tfstate/main.tf
@@ -1,0 +1,116 @@
+data "aws_partition" "current" {}
+
+resource "aws_kms_key" "this" {
+  description             = "For ${var.name} bucket and table for terraform state"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "this" {
+  name          = "alias/${var.name}"
+  target_key_id = aws_kms_key.this.key_id
+}
+
+data "aws_iam_policy_document" "tls_only" {
+  statement {
+    sid = "enforce-tls-requests-only"
+
+    effect = "Deny"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${var.name}",
+      "arn:${data.aws_partition.current.partition}:s3:::${var.name}/*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.tls_only.json
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.this.key_id
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "${var.name}-logs"
+}
+
+resource "aws_s3_bucket_policy" "logs" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.tls_only.json
+}
+
+resource "aws_s3_bucket_versioning" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.this.key_id
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_logging" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  target_bucket = aws_s3_bucket.logs.id
+  target_prefix = "s3/"
+}
+
+resource "aws_dynamodb_table" "this" {
+  name     = var.name
+  hash_key = "LockID"
+
+  billing_mode = "PAY_PER_REQUEST"
+
+  server_side_encryption {
+    enabled = true
+    kms_key_arn = aws_kms_key.this.arn
+  }
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/terraform/services/tfstate/main.tf
+++ b/terraform/services/tfstate/main.tf
@@ -105,7 +105,7 @@ resource "aws_dynamodb_table" "this" {
   billing_mode = "PAY_PER_REQUEST"
 
   server_side_encryption {
-    enabled = true
+    enabled     = true
     kms_key_arn = aws_kms_key.this.arn
   }
 

--- a/terraform/services/tfstate/outputs.tf
+++ b/terraform/services/tfstate/outputs.tf
@@ -1,0 +1,12 @@
+data "aws_region" "current" {}
+
+output "backend_config" {
+  description = "Text for the tfbackend file"
+  value       = <<EOT
+bucket         = "${aws_s3_bucket.this.id}"
+dynamodb_table = "${aws_dynamodb_table.this.id}"
+region         = "${data.aws_region.current.name}"
+encrypt        = true
+kms_key_id     = "${aws_kms_alias.this.name}"
+EOT
+}

--- a/terraform/services/tfstate/variables.tf
+++ b/terraform/services/tfstate/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  description = "Name for the S3 bucket and DynamoDB table"
+  type        = string
+}

--- a/terraform/services/tfstate/versions.tf
+++ b/terraform/services/tfstate/versions.tf
@@ -2,7 +2,7 @@ provider "aws" {
   region = "us-east-1"
   default_tags {
     tags = {
-      business  = "oeda"
+      business = "oeda"
     }
   }
 }

--- a/terraform/services/tfstate/versions.tf
+++ b/terraform/services/tfstate/versions.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  region = "us-east-1"
+  default_tags {
+    tags = {
+      business  = "oeda"
+    }
+  }
+}
+
+terraform {
+  # Uncomment backend and init with -backend-config to migrate to and manage remote state
+  #backend "s3" {
+  #  key = "tfstate/terraform.tfstate"
+  #}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.8.0"
+    }
+  }
+  required_version = "~> 1.5.5"
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-279

## 🛠 Changes

Added a service to create resources for remote terraform state in AWS.

## ℹ️ Context for reviewers

This is a bootstrap service to get us up and running with new resources for remote terraform state when needed. Currently useful as we initialize new backends for terraform in this platform repo, and should be useful when we transition teams to v4 AWS accounts.

## ✅ Acceptance Validation

Successfully applied to create new backends for remote state.

## 🔒 Security Implications

None.