### PR TITLE
PLT-278 Fix GitHub runner policy

### DIFF
--- a/terraform/services/github-actions/main.tf
+++ b/terraform/services/github-actions/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy" "developer_boundary_policy" {
 data "aws_iam_policy_document" "runner" {
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = ["arn:aws:iam::*:role/delegatedadmin/developer/github-actions-deploy"]
+    resources = ["arn:aws:iam::*:role/delegatedadmin/developer/*-github-actions-deploy"]
   }
 }
 

--- a/terraform/services/github-actions/main.tf
+++ b/terraform/services/github-actions/main.tf
@@ -28,6 +28,7 @@ data "aws_iam_policy_document" "runner" {
 
 resource "aws_iam_policy" "runner" {
   name = "github-actions-runner"
+  path = "/delegatedadmin/developer/"
 
   description = "The runner has permission to assume the GitHub Actions deploy role in any account"
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-278

## 🛠 Changes

Modified path and resource to fix IAM policy for GitHub runner.

## ℹ️ Context for reviewers

The permissions boundary for the deploy role won't allow management of policies outside of the /delegatedadmin/developer/ path, and I updated the deploy roles to include the application environment.

## ✅ Acceptance Validation

I had to delete the policy manually with an IAM user with direct access to the account. This should now apply cleanly once merged.

## 🔒 Security Implications

None.