### PR TITLE
PLT-277 Switch gold image vars to aws params

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -8,7 +8,7 @@ on:
     # 00:00 on Monday each week
     - cron: "0 0 * * 1"
   workflow_dispatch:
-    
+
 jobs:
   build-image:
     name: Build
@@ -29,7 +29,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: ${{ vars.RUNNER_ACCOUNT_ROLE }}
+          role-to-assume: ${{ vars.BCDA_MGMT_DEPLOY_ROLE }}
           aws-region: us-east-1
 
       - name: Retrieve default VPC ID and subnet

--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -19,9 +19,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    env:
-      AMI_ACCOUNT: ${{ vars.RUNNER_AMI_ACCOUNT }}
-      AMI_FILTER: ${{ vars.RUNNER_AMI_FILTER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -30,7 +27,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ vars.BCDA_MGMT_DEPLOY_ROLE }}
-          aws-region: us-east-1
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        with:
+          params: |
+            AMI_ACCOUNT=/gold-image/account
+            AMI_FILTER=/gold-image/filter
 
       - name: Retrieve default VPC ID and subnet
         id: vpc


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-277

## 🛠 Changes

Switched out gold image AMI variables to pull in values from AWS Parameter Store. Also updated deploy role.

## ℹ️ Context for reviewers

In an effort to keep secrets and variables in AWS instead of GitHub, I've set gold image params in the management account.

## ✅ Acceptance Validation

See checks. The build is failing due to an IAM PassRole issue with the bcda-packer role, likely because it isn't within the /delegatedadmin/developer/ path. We should still merge this and address that in another PR.

## 🔒 Security Implications

None.