### PR TITLE
PLT-285: Image building must not use bcda-packer role

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/build-runner-images.yml
+      - packer/github-actions-runner
   schedule:
     # 00:00 on Monday each week
     - cron: "0 0 * * 1"

--- a/packer/github-actions-runner/sources.pkr.hcl
+++ b/packer/github-actions-runner/sources.pkr.hcl
@@ -24,7 +24,7 @@ source "amazon-ebs" "github-actions-runner" {
   ssh_username = "ec2-user"
   ssh_timeout = "1h"
   ssh_pty = true
-  iam_instance_profile = "bcda-packer"
+  iam_instance_profile = "bcda-mgmt-github-actions-deploy"
 
   tags = {
     Name = "github-actions-runner-ami",


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-285

## 🛠 Changes

Changes the role for building the images. The bcda-packer role is not within the permissions boundary.

## 🔒 Security Implications

None.