### PR TITLE
PLT-278 Allow runner to get parameters

### DIFF
--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "runner" {
   name = "github-actions-runner"
   path = "/delegatedadmin/developer/"
 
-  description = "The runner has permission to assume the GitHub Actions deploy role in any account and get individual parameters"
+  description = "The runner has permission to assume the GitHub Actions deploy role in any account and get parameters"
 
   policy = data.aws_iam_policy_document.runner.json
 }

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -24,6 +24,10 @@ data "aws_iam_policy_document" "runner" {
     actions   = ["sts:AssumeRole"]
     resources = ["arn:aws:iam::*:role/delegatedadmin/developer/*-github-actions-deploy"]
   }
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = ["*"]
+  }
 }
 
 # Due to the developer-boundary-policy permissions boundary, this policy cannot be created by
@@ -33,7 +37,7 @@ resource "aws_iam_policy" "runner" {
   name = "github-actions-runner"
   path = "/delegatedadmin/developer/"
 
-  description = "The runner has permission to assume the GitHub Actions deploy role in any account"
+  description = "The runner has permission to assume the GitHub Actions deploy role in any account and get individual parameters"
 
   policy = data.aws_iam_policy_document.runner.json
 }

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "runner" {
     resources = ["arn:aws:iam::*:role/delegatedadmin/developer/*-github-actions-deploy"]
   }
   statement {
-    actions = ["ssm:GetParameters"]
+    actions   = ["ssm:GetParameters"]
     resources = ["*"]
   }
 }

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "runner" {
     resources = ["arn:aws:iam::*:role/delegatedadmin/developer/*-github-actions-deploy"]
   }
   statement {
-    actions = ["ssm:GetParameter"]
+    actions = ["ssm:GetParameters"]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-278

## 🛠 Changes

Allow the GitHub Actions runner role to retrieve parameters from the management account.

## ℹ️ Context for reviewers

This allows for workflows like https://github.com/CMSgov/ab2d/blob/7bfa9085ade3537f5a2dd4203debd936aa1b4814/.github/workflows/unit-integration-test.yml to set shared ARTIFACTORY and SONAR params from the management account before assuming a role.

## ✅ Acceptance Validation

See checks for terraform plan. I'll test with the workflow above after merge.

## 🔒 Security Implications

None.