### PR TITLE
PLT-278 Add TagSession permission, required for assume

### DIFF
--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -21,7 +21,10 @@ data "aws_iam_policy" "developer_boundary_policy" {
 
 data "aws_iam_policy_document" "runner" {
   statement {
-    actions   = ["sts:AssumeRole"]
+    actions   = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
     resources = ["arn:aws:iam::*:role/delegatedadmin/developer/*-github-actions-deploy"]
   }
   statement {

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy" "developer_boundary_policy" {
 
 data "aws_iam_policy_document" "runner" {
   statement {
-    actions   = [
+    actions = [
       "sts:AssumeRole",
       "sts:TagSession",
     ]


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-278

## 🛠 Changes

Add TagSession permission for the runner role.

## ℹ️ Context for reviewers

The TagSession permission is also required to assume a role. Without it we get this error:

```
Error: Could not assume role with user credentials: User: arn:aws:sts::xxxxxxxxxx:assumed-role/github-actions-runner-role/i-xxxxxxxxxxxxx is not authorized to perform: sts:TagSession on resource: arn:aws:iam::xxxxxxxxxxxxx:role/delegatedadmin/developer/ab2d-dev-github-actions-deploy
```

## ✅ Acceptance Validation

I'll test in https://github.com/CMSgov/ab2d/pull/1306 once this is merged.

## 🔒 Security Implications

None.