### PR TITLE
PLT-285 Drop instance profile from packer sources

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/build-runner-images.yml
-      - packer/github-actions-runner
+      - packer/github-actions-runner/**
   schedule:
     # 00:00 on Monday each week
     - cron: "0 0 * * 1"

--- a/packer/github-actions-runner/sources.pkr.hcl
+++ b/packer/github-actions-runner/sources.pkr.hcl
@@ -24,7 +24,6 @@ source "amazon-ebs" "github-actions-runner" {
   ssh_username = "ec2-user"
   ssh_timeout = "1h"
   ssh_pty = true
-  iam_instance_profile = "bcda-mgmt-github-actions-deploy"
 
   tags = {
     Name = "github-actions-runner-ami",

--- a/terraform/services/github-actions-deploy-role/main.tf
+++ b/terraform/services/github-actions-deploy-role/main.tf
@@ -68,9 +68,3 @@ resource "aws_iam_role" "github_actions_deploy" {
     policy = data.aws_iam_policy_document.github_actions_deploy_inline.json
   }
 }
-
-resource "aws_iam_instance_profile" "github_actions_deploy" {
-  name = "${var.app_team}-${var.app_env}-github-actions-deploy"
-  path = "/delegatedadmin/developer/"
-  role = aws_iam_role.github_actions_deploy.name
-}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-285

## 🛠 Changes

Dropped iam_instance_profile from packer sources.

## ℹ️ Context for reviewers

It appears that iam_instance_profile is only needed when using session manager to connect to the instance for building. 

https://github.com/hashicorp/packer-plugin-amazon/blob/2f6ed10096b416c957b7a33d198d19f5e6000971/docs-partials/builders/aws-session-manager.mdx#L10

## ✅ Acceptance Validation

See checks.

## 🔒 Security Implications

None.
