### PR TITLE
PLT-277: Switch GitHub runners to use the AMI we build

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -33,8 +33,8 @@ jobs:
       - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         with:
           params: |
-            AMI_ACCOUNT=/github-actions-runner-ami/account
-            AMI_FILTER=/github-actions-runner-ami/filter
+            AMI_ACCOUNT=/github-runner/gold-image-account
+            AMI_FILTER=/github-runner/gold-image-filter
 
       - name: Retrieve default VPC ID and subnet
         id: vpc

--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -33,8 +33,8 @@ jobs:
       - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         with:
           params: |
-            AMI_ACCOUNT=/gold-image/account
-            AMI_FILTER=/gold-image/filter
+            AMI_ACCOUNT=/github-actions-runner-ami/account
+            AMI_FILTER=/github-actions-runner-ami/filter
 
       - name: Retrieve default VPC ID and subnet
         id: vpc

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -80,6 +80,7 @@ module "github-actions-runner" {
   role_permissions_boundary = data.aws_iam_policy.developer_boundary_policy.arn
 
   enable_ssm_on_runners = true
+  enable_userdata = false
 
   idle_config = [{
     cron             = "* * 9-17 * * 1-5"

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -80,7 +80,7 @@ module "github-actions-runner" {
   role_permissions_boundary = data.aws_iam_policy.developer_boundary_policy.arn
 
   enable_ssm_on_runners = true
-  enable_userdata = false
+  enable_userdata       = false
 
   idle_config = [{
     cron             = "* * 9-17 * * 1-5"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-277

## 🛠 Changes

Changing the image our runner image builds work on to the latest prebuilt runner image.

## ℹ️ Context for reviewers

We successfully built an image using packer, but we are still using the old amzn2legacy image.

## ✅ Acceptance Validation

Image builds successfully.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.
