### PR TITLE
PLT-176 Fixes to get opt-out-import apply working across environments

### DIFF
--- a/.github/workflows/github-actions-deploy-role-apply.yml
+++ b/.github/workflows/github-actions-deploy-role-apply.yml
@@ -14,10 +14,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./terraform/services/github-actions-deploy-role
     strategy:
       fail-fast: false
       matrix:
@@ -26,17 +22,9 @@ jobs:
         include:
           - app: bcda
             env: mgmt
-    environment: ${{ matrix.app }}-${{ matrix.env }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./actions/setup-tfenv-terraform
-      - uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', matrix.app, matrix.env)] }}
-          aws-region: ${{ vars.AWS_REGION }}
-      - run: terraform init -backend-config=../../backends/${{ matrix.app}}-${{ matrix.env }}.s3.tfbackend
-      - run: terraform apply -auto-approve
-        env:
-          TF_VAR_app_team: ${{ matrix.app }}
-          TF_VAR_app_env: ${{ matrix.env }}
-          TF_VAR_runner_arn: ${{ vars.RUNNER_ROLE }}
+    uses: ./.github/workflows/terraform-command.yml
+    with:
+      app: ${{ matrix.app }}
+      env: ${{ matrix.env }}
+      dir: ./terraform/services/github-actions-deploy-role
+      cmd: apply -auto-approve

--- a/.github/workflows/github-actions-deploy-role-plan.yml
+++ b/.github/workflows/github-actions-deploy-role-plan.yml
@@ -20,10 +20,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./terraform/services/github-actions-deploy-role
     strategy:
       fail-fast: false
       matrix:
@@ -32,16 +28,9 @@ jobs:
         include:
           - app: bcda
             env: mgmt
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./actions/setup-tfenv-terraform
-      - uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', matrix.app, matrix.env)] }}
-          aws-region: ${{ vars.AWS_REGION }}
-      - run: terraform init -backend-config=../../backends/${{ matrix.app}}-${{ matrix.env }}.s3.tfbackend
-      - run: terraform plan
-        env:
-          TF_VAR_app_team: ${{ matrix.app }}
-          TF_VAR_app_env: ${{ matrix.env }}
-          TF_VAR_runner_arn: ${{ vars.RUNNER_ROLE }}
+    uses: ./.github/workflows/terraform-command.yml
+    with:
+      app: ${{ matrix.app }}
+      env: ${{ matrix.env }}
+      dir: ./terraform/services/github-actions-deploy-role
+      cmd: plan

--- a/.github/workflows/github-actions-oidc-provider-apply.yml
+++ b/.github/workflows/github-actions-oidc-provider-apply.yml
@@ -14,10 +14,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./terraform/services/github-actions-oidc-provider
     strategy:
       fail-fast: false
       matrix:
@@ -26,13 +22,9 @@ jobs:
         include:
           - app: bcda
             env: mgmt
-    environment: ${{ matrix.app }}-${{ matrix.env }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./actions/setup-tfenv-terraform
-      - uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', matrix.app, matrix.env)] }}
-          aws-region: ${{ vars.AWS_REGION }}
-      - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
-      - run: terraform apply -auto-approve
+    uses: ./.github/workflows/terraform-command.yml
+    with:
+      app: ${{ matrix.app }}
+      env: ${{ matrix.env }}
+      dir: ./terraform/services/github-actions-oidc-provider
+      cmd: apply -auto-approve

--- a/.github/workflows/github-actions-oidc-provider-plan.yml
+++ b/.github/workflows/github-actions-oidc-provider-plan.yml
@@ -20,10 +20,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./terraform/services/github-actions-oidc-provider
     strategy:
       fail-fast: false
       matrix:
@@ -32,12 +28,9 @@ jobs:
         include:
           - app: bcda
             env: mgmt
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./actions/setup-tfenv-terraform
-      - uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', matrix.app, matrix.env)] }}
-          aws-region: ${{ vars.AWS_REGION }}
-      - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
-      - run: terraform plan
+    uses: ./.github/workflows/terraform-command.yml
+    with:
+      app: ${{ matrix.app }}
+      env: ${{ matrix.env }}
+      dir: ./terraform/services/github-actions-oidc-provider
+      cmd: plan

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-    uses: ./.github/workflows/tf-cmd.yml@main
+    uses: ./.github/workflows/tf-cmd.yml
     with:
       app: ${{ matrix.app }}
       env: ${{ matrix.env }}

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-    uses: ./.github/workflows/tf-cmd.yml
+    uses: ./.github/workflows/terraform-command.yml
     with:
       app: ${{ matrix.app }}
       env: ${{ matrix.env }}

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -14,25 +14,14 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./terraform/services/opt-out-import
     strategy:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-    environment: ${{ matrix.app }}-${{ matrix.env }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./actions/setup-tfenv-terraform
-      - uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', matrix.app, matrix.env)] }}
-          aws-region: ${{ vars.AWS_REGION }}
-      - run: terraform init -reconfigure -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
-      - run: terraform apply -auto-approve
-        env:
-          TF_VAR_app_team: ${{ matrix.app }}
-          TF_VAR_app_env: ${{ matrix.env }}
+    uses: ./.github/workflows/tf-cmd.yml@main
+    with:
+      app: ${{ matrix.app }}
+      env: ${{ matrix.env }}
+      dir: ./terraform/services/opt-out-import
+      cmd: apply -auto-approve

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -23,16 +23,6 @@ jobs:
       matrix:
         app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-        include:
-          - app: ab2d
-            handler: gov.cms.ab2d.optout.OptOutHandler
-            runtime: java11
-          - app: bcda
-            handler: bootstrap
-            runtime: provided.al2
-          - app: dpc
-            handler: bootstrap
-            runtime: provided.al2
     environment: ${{ matrix.app }}-${{ matrix.env }}
     steps:
       - uses: actions/checkout@v4
@@ -42,14 +32,7 @@ jobs:
           role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', matrix.app, matrix.env)] }}
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
-      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        with:
-          params: |
-            TF_VAR_bfd_bucket_role_arn=/opt-out-import/${{ matrix.app }}/${{ matrix.env }}/bfd-bucket-role-arn
-            TF_VAR_bfd_sns_topic_arn=/opt-out-import/${{ matrix.app }}/${{ matrix.env }}/bfd-sns-topic-arn
       - run: terraform apply -auto-approve
         env:
           TF_VAR_app_team: ${{ matrix.app }}
           TF_VAR_app_env: ${{ matrix.env }}
-          TF_VAR_lambda_handler: ${{ matrix.handler }}
-          TF_VAR_lambda_runtime: ${{ matrix.runtime }}

--- a/.github/workflows/opt-out-import-plan.yml
+++ b/.github/workflows/opt-out-import-plan.yml
@@ -29,16 +29,6 @@ jobs:
       matrix:
         app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-        include:
-          - app: ab2d
-            handler: gov.cms.ab2d.optout.OptOutHandler
-            runtime: java11
-          - app: bcda
-            handler: bootstrap
-            runtime: provided.al2
-          - app: dpc
-            handler: bootstrap
-            runtime: provided.al2
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform
@@ -47,14 +37,7 @@ jobs:
           role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', matrix.app, matrix.env)] }}
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
-      - uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        with:
-          params: |
-            TF_VAR_bfd_bucket_role_arn=/opt-out-import/${{ matrix.app }}/${{ matrix.env }}/bfd-bucket-role-arn
-            TF_VAR_bfd_sns_topic_arn=/opt-out-import/${{ matrix.app }}/${{ matrix.env }}/bfd-sns-topic-arn
       - run: terraform plan
         env:
           TF_VAR_app_team: ${{ matrix.app }}
           TF_VAR_app_env: ${{ matrix.env }}
-          TF_VAR_lambda_handler: ${{ matrix.handler }}
-          TF_VAR_lambda_runtime: ${{ matrix.runtime }}

--- a/.github/workflows/opt-out-import-plan.yml
+++ b/.github/workflows/opt-out-import-plan.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-    uses: ./.github/workflows/tf-cmd.yml
+    uses: ./.github/workflows/terraform-command.yml
     with:
       app: ${{ matrix.app }}
       env: ${{ matrix.env }}

--- a/.github/workflows/opt-out-import-plan.yml
+++ b/.github/workflows/opt-out-import-plan.yml
@@ -20,24 +20,14 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./terraform/services/opt-out-import
     strategy:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./actions/setup-tfenv-terraform
-      - uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', matrix.app, matrix.env)] }}
-          aws-region: ${{ vars.AWS_REGION }}
-      - run: terraform init -reconfigure -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
-      - run: terraform plan
-        env:
-          TF_VAR_app_team: ${{ matrix.app }}
-          TF_VAR_app_env: ${{ matrix.env }}
+    uses: ./.github/workflows/tf-cmd.yml@main
+    with:
+      app: ${{ matrix.app }}
+      env: ${{ matrix.env }}
+      dir: ./terraform/services/opt-out-import
+      cmd: plan

--- a/.github/workflows/opt-out-import-plan.yml
+++ b/.github/workflows/opt-out-import-plan.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-    uses: ./.github/workflows/tf-cmd.yml@main
+    uses: ./.github/workflows/tf-cmd.yml
     with:
       app: ${{ matrix.app }}
       env: ${{ matrix.env }}

--- a/.github/workflows/terraform-command.yml
+++ b/.github/workflows/terraform-command.yml
@@ -55,4 +55,7 @@ jobs:
           role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', inputs.app, inputs.env)] }}
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/${{ inputs.app }}-${{ inputs.env }}.s3.tfbackend
-      - run: terraform ${{ inputs.cmd }} -var app=${{ inputs.app }} -var env=${{ inputs.env }}
+      - run: terraform ${{ inputs.cmd }}
+        env:
+          TF_VAR_app: ${{ matrix.app }}
+          TF_VAR_env: ${{ matrix.env }}

--- a/.github/workflows/terraform-command.yml
+++ b/.github/workflows/terraform-command.yml
@@ -39,7 +39,7 @@ on:
         type: string
 
 jobs:
-  tf:
+  terraform-command:
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/terraform-command.yml
+++ b/.github/workflows/terraform-command.yml
@@ -57,5 +57,5 @@ jobs:
       - run: terraform init -reconfigure -backend-config=../../backends/${{ inputs.app }}-${{ inputs.env }}.s3.tfbackend
       - run: terraform ${{ inputs.cmd }}
         env:
-          TF_VAR_app: ${{ matrix.app }}
-          TF_VAR_env: ${{ matrix.env }}
+          TF_VAR_app: ${{ inputs.app }}
+          TF_VAR_env: ${{ inputs.env }}

--- a/.github/workflows/tf-cmd.yml
+++ b/.github/workflows/tf-cmd.yml
@@ -1,0 +1,58 @@
+name: Run a terraform command in a directory
+
+on:
+  workflow_call:
+    inputs:
+      app:
+        description: Application name (ab2d, bcda, dpc, etc.)
+        required: true
+        type: string
+      env:
+        description: Application environment (dev, test, prod, sbx)
+        required: true
+        type: string
+      dir:
+        description: Terraform execution directory
+        required: true
+        type: string
+      cmd:
+        description: Terraform subcommand
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      app:
+        description: Application name (ab2d, bcda, dpc, etc.)
+        required: true
+        type: string
+      env:
+        description: Application environment (dev, test, prod, sbx)
+        required: true
+        type: string
+      dir:
+        description: Terraform execution directory
+        required: true
+        type: string
+      cmd:
+        description: Terraform subcommand
+        required: true
+        type: string
+
+jobs:
+  tf:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.dir }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ vars[format('{0}_{1}_DEPLOY_ROLE', inputs.app, inputs.env)] }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/${{ inputs.app }}-${{ inputs.env }}.s3.tfbackend
+      - run: terraform ${{ inputs.cmd }} -var app=${{ inputs.app }} -var env=${{ inputs.env }}

--- a/scripts/tf-apply-bcda-dpc
+++ b/scripts/tf-apply-bcda-dpc
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Only bcda and dpc for now since each ab2d env is in its own account
+apps="bcda dpc"
+envs="dev test prod sbx"
+
+for app in $apps; do
+  export TF_VAR_app=$app
+  for env in $envs; do
+    export TF_VAR_env=$env
+    terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
+    terraform apply
+  done
+done

--- a/scripts/tf-apply-bcda-dpc
+++ b/scripts/tf-apply-bcda-dpc
@@ -4,7 +4,7 @@ set -ex
 
 # Only bcda and dpc for now since each ab2d env is in its own account
 apps="bcda dpc"
-envs="dev test prod sbx"
+envs="test dev prod sbx"
 
 for app in $apps; do
   export TF_VAR_app=$app

--- a/scripts/tf-import-bcda-dpc
+++ b/scripts/tf-import-bcda-dpc
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Only bcda and dpc for now since each ab2d env is in its own account
+apps="bcda dpc"
+envs="dev test prod sbx"
+
+for app in $apps; do
+  export TF_VAR_app=$app
+  for env in $envs; do
+    export TF_VAR_env=$env
+    terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
+    terraform import module.opt_out_import_lambda.aws_iam_role.lambda $TF_VAR_app-$TF_VAR_env-opt-out-import-lambda
+  done
+done

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -54,12 +54,14 @@ resource "aws_iam_role" "lambda" {
     name   = "default-lambda"
     policy = data.aws_iam_policy_document.lambda_inline.json
   }
-}
 
-resource "aws_iam_role_policy_attachment" "managed_policies" {
-  count      = length(var.lambda_role_managed_policy_arns)
-  role       = aws_iam_role.lambda.name
-  policy_arn = element(var.lambda_role_managed_policy_arns, count.index)
+  dynamic "inline_policy" {
+    for_each = var.lambda_role_inline_policies
+    content {
+      name   = inline_policy.key
+      policy = inline_policy.value
+    }
+  }
 }
 
 resource "aws_s3_bucket" "lambda_zip_file" {

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -25,10 +25,10 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "lambda_role_managed_policy_arns" {
-  description = "Attach AWS or customer-managed IAM policies (by ARN) to the lambda IAM role"
-  type        = list(string)
-  default     = []
+variable "lambda_role_inline_policies" {
+  description = "Inline policies (in JSON) for the lambda IAM role"
+  type        = map(string)
+  default     = {}
 }
 
 variable "subnet_ids" {

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -1,3 +1,21 @@
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
+  type        = string
+  validation {
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, sbx, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, sbx, or prod."
+  }
+}
+
 variable "function_name" {
   description = "Name of the lambda function"
   type        = string
@@ -20,20 +38,10 @@ variable "runtime" {
   default     = "python3.11"
 }
 
-variable "vpc_id" {
-  description = "ID for the AWS VPC"
-  type        = string
-}
-
 variable "lambda_role_inline_policies" {
   description = "Inline policies (in JSON) for the lambda IAM role"
   type        = map(string)
   default     = {}
-}
-
-variable "subnet_ids" {
-  description = "List of subnet IDs for the Lambda function"
-  type        = list(string)
 }
 
 variable "security_group_ids" {

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -48,6 +48,12 @@ variable "environment_variables" {
   default     = {}
 }
 
+variable "promotion_roles" {
+  description = "List of ARNs to allow access for deploy roles to promote lambda zip files to upper environments"
+  type        = list(string)
+  default     = []
+}
+
 variable "create_function_zip" {
   description = "Create the function zip file, necessary for initialization (defaults to true)"
   type        = bool

--- a/terraform/modules/queue/variables.tf
+++ b/terraform/modules/queue/variables.tf
@@ -11,4 +11,7 @@ variable "function_name" {
 variable "sns_topic_arn" {
   description = "ARN of the SNS topic to subscribe to"
   type        = string
+  # Setting default to "None" allows us to set the AWS Parameter Store value
+  # to "None" to disable creation of SNS Topic Subscription
+  default     = "None"
 }

--- a/terraform/modules/subnets/main.tf
+++ b/terraform/modules/subnets/main.tf
@@ -4,14 +4,14 @@ data "aws_subnets" "this" {
     values = [var.vpc_id]
   }
   dynamic "filter" {
-    for_each = var.app_team == "bcda" || var.app_team == "dpc" ? [1] : []
+    for_each = var.app == "bcda" || var.app == "dpc" ? [1] : []
     content {
       name   = "tag:Layer"
       values = [var.layer]
     }
   }
   dynamic "filter" {
-    for_each = var.app_team == "ab2d" ? [1] : []
+    for_each = var.app == "ab2d" ? [1] : []
     content {
       name   = "tag:use"
       values = [var.use]

--- a/terraform/modules/subnets/variables.tf
+++ b/terraform/modules/subnets/variables.tf
@@ -3,12 +3,12 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "app_team" {
-  description = "The application team (ab2d, bcda, dpc)"
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
   type        = string
   validation {
-    condition     = contains(["ab2d", "bcda", "dpc"], var.app_team)
-    error_message = "Valid value for app_team is ab2d, bcda, or dpc."
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
   }
 }
 

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -2,18 +2,18 @@ data "aws_vpc" "this" {
   filter {
     name = "tag:stack"
     values = [
-      var.app_env == "sbx" && var.app_team == "ab2d" ? "sandbox" :
-      var.app_env == "sbx" && var.app_team == "bcda" ? "opensbx" :
-      var.app_env == "sbx" && var.app_team == "dpc" ? "prod-sbx" :
-      var.app_env == "test" && var.app_team == "ab2d" ? "impl" :
-      var.app_env
+      var.env == "sbx" && var.app == "ab2d" ? "sandbox" :
+      var.env == "sbx" && var.app == "bcda" ? "opensbx" :
+      var.env == "sbx" && var.app == "dpc" ? "prod-sbx" :
+      var.env == "test" && var.app == "ab2d" ? "impl" :
+      var.env
     ]
   }
   dynamic "filter" {
-    for_each = var.app_team == "bcda" || var.app_team == "dpc" ? [1] : []
+    for_each = var.app == "bcda" || var.app == "dpc" ? [1] : []
     content {
       name   = "tag:application"
-      values = [var.app_team]
+      values = [var.app]
     }
   }
 }

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,17 +1,17 @@
-variable "app_team" {
-  description = "The application team (ab2d, bcda, dpc)"
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
   type        = string
   validation {
-    condition     = contains(["ab2d", "bcda", "dpc"], var.app_team)
-    error_message = "Valid value for app_team is ab2d, bcda, or dpc."
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
   }
 }
 
-variable "app_env" {
+variable "env" {
   description = "The application environment (dev, test, sbx, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "sbx", "prod"], var.app_env)
-    error_message = "Valid value for app_env is dev, test, sbx, or prod."
+    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, sbx, or prod."
   }
 }

--- a/terraform/services/github-actions-deploy-role/main.tf
+++ b/terraform/services/github-actions-deploy-role/main.tf
@@ -6,6 +6,10 @@ data "aws_iam_openid_connect_provider" "github" {
   url = "https://${local.provider_domain}"
 }
 
+data "aws_ssm_parameter" "github_runner_role_arn" {
+  name = "/github-runner/role-arn"
+}
+
 data "aws_iam_policy_document" "github_actions_deploy_assume" {
   statement {
     actions = [
@@ -15,7 +19,7 @@ data "aws_iam_policy_document" "github_actions_deploy_assume" {
 
     principals {
       type        = "AWS"
-      identifiers = [var.runner_arn]
+      identifiers = [data.aws_ssm_parameter.github_runner_role_arn.value]
     }
   }
 
@@ -56,7 +60,7 @@ data "aws_iam_policy_document" "github_actions_deploy_inline" {
 }
 
 resource "aws_iam_role" "github_actions_deploy" {
-  name = "${var.app_team}-${var.app_env}-github-actions-deploy"
+  name = "${var.app}-${var.env}-github-actions-deploy"
   path = "/delegatedadmin/developer/"
 
   assume_role_policy = data.aws_iam_policy_document.github_actions_deploy_assume.json

--- a/terraform/services/github-actions-deploy-role/main.tf
+++ b/terraform/services/github-actions-deploy-role/main.tf
@@ -48,8 +48,8 @@ data "aws_iam_policy_document" "github_actions_deploy_assume" {
   }
 }
 
-data "aws_iam_policy" "developer_boundary_policy" {
-  name = "developer-boundary-policy"
+data "aws_iam_policy" "poweruser_boundary" {
+  name = "ct-ado-poweruser-permissions-boundary-policy"
 }
 
 data "aws_iam_policy_document" "github_actions_deploy_inline" {
@@ -65,7 +65,7 @@ resource "aws_iam_role" "github_actions_deploy" {
 
   assume_role_policy = data.aws_iam_policy_document.github_actions_deploy_assume.json
 
-  permissions_boundary = data.aws_iam_policy.developer_boundary_policy.arn
+  permissions_boundary = data.aws_iam_policy.poweruser_boundary.arn
 
   inline_policy {
     name   = "github-actions-deploy"

--- a/terraform/services/github-actions-deploy-role/variables.tf
+++ b/terraform/services/github-actions-deploy-role/variables.tf
@@ -1,22 +1,17 @@
-variable "app_team" {
-  description = "The application team (ab2d, bcda, dpc)"
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
   type        = string
   validation {
-    condition     = contains(["ab2d", "bcda", "dpc"], var.app_team)
-    error_message = "Valid value for app_team is ab2d, bcda, or dpc."
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
   }
 }
 
-variable "app_env" {
+variable "env" {
   description = "The application environment (dev, test, mgmt, sbx, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "mgmt", "sbx", "prod"], var.app_env)
-    error_message = "Valid value for app_env is dev, test, mgmt, sbx, or prod."
+    condition     = contains(["dev", "test", "mgmt", "sbx", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, mgmt, sbx, or prod."
   }
-}
-
-variable "runner_arn" {
-  description = "The arn for the runner role in the mgmt account that may assume this role"
-  type        = string
 }

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -1,24 +1,24 @@
 locals {
-  full_name = "${var.app_team}-${var.app_env}-opt-out-import"
+  full_name = "${var.app}-${var.env}-opt-out-import"
 }
 
 module "vpc" {
   source = "../../modules/vpc"
 
-  app_team = var.app_team
-  app_env  = var.app_env
+  app = var.app
+  env = var.env
 }
 
 module "subnets" {
   source = "../../modules/subnets"
 
-  vpc_id   = module.vpc.vpc_id
-  app_team = var.app_team
-  layer    = "data"
+  vpc_id = module.vpc.vpc_id
+  app    = var.app
+  layer  = "data"
 }
 
 data "aws_ssm_parameter" "bfd_bucket_role_arn" {
-  name = "/opt-out-import/${var.app_team}/${var.app_env}/bfd-bucket-role-arn"
+  name = "/opt-out-import/${var.app}/${var.env}/bfd-bucket-role-arn"
 }
 
 data "aws_iam_policy_document" "assume_bucket_role" {
@@ -30,13 +30,13 @@ data "aws_iam_policy_document" "assume_bucket_role" {
 
 # Prod and sbx deploy roles are only needed in the test environment
 data "aws_ssm_parameter" "prod_deploy_role_arn" {
-  count = var.app_env == "test" ? 1 : 0
-  name  = "/${var.app_team}/prod/deploy-role-arn"
+  count = var.env == "test" ? 1 : 0
+  name  = "/${var.app}/prod/deploy-role-arn"
 }
 
 data "aws_ssm_parameter" "sbx_deploy_role_arn" {
-  count = var.app_env == "test" ? 1 : 0
-  name  = "/${var.app_team}/sbx/deploy-role-arn"
+  count = var.env == "test" ? 1 : 0
+  name  = "/${var.app}/sbx/deploy-role-arn"
 }
 
 module "opt_out_import_lambda" {
@@ -45,8 +45,8 @@ module "opt_out_import_lambda" {
   function_name        = local.full_name
   function_description = "Ingests the most recent beneficiary opt-out list from BFD"
 
-  handler = var.app_team == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"
-  runtime = var.app_team == "ab2d" ? "java11" : "provided.al2"
+  handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"
+  runtime = var.app == "ab2d" ? "java11" : "provided.al2"
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.subnets.subnet_ids
@@ -56,18 +56,18 @@ module "opt_out_import_lambda" {
   }
 
   environment_variables = {
-    ENV      = var.app_env
-    APP_NAME = "${var.app_team}-${var.app_env}-opt-out-import"
+    ENV      = var.env
+    APP_NAME = "${var.app}-${var.env}-opt-out-import"
   }
 
-  promotion_roles = var.app_env != "test" ? [] : [
+  promotion_roles = var.env != "test" ? [] : [
     data.aws_ssm_parameter.prod_deploy_role_arn[0].value,
     data.aws_ssm_parameter.sbx_deploy_role_arn[0].value,
   ]
 }
 
 data "aws_ssm_parameter" "bfd_sns_topic_arn" {
-  name = "/opt-out-import/${var.app_team}/${var.app_env}/bfd-sns-topic-arn"
+  name = "/opt-out-import/${var.app}/${var.env}/bfd-sns-topic-arn"
 }
 
 module "opt_out_import_queue" {

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -24,15 +24,6 @@ data "aws_iam_policy_document" "assume_bucket_role" {
   }
 }
 
-resource "aws_iam_policy" "assume_bucket_role" {
-  name = "${local.full_name}-assume-bucket-role"
-  path = "/delegatedadmin/developer/"
-
-  description = "Allows the ${local.full_name} lambda role to assume the bucket role in the BFD account"
-
-  policy = data.aws_iam_policy_document.assume_bucket_role.json
-}
-
 module "opt_out_import_lambda" {
   source = "../../modules/lambda"
 
@@ -45,7 +36,9 @@ module "opt_out_import_lambda" {
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.subnets.subnet_ids
 
-  lambda_role_managed_policy_arns = [aws_iam_policy.assume_bucket_role.arn]
+  lambda_role_inline_policies = {
+    assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json
+  }
 
   environment_variables = {
     ENV      = var.app_env

--- a/terraform/services/opt-out-import/terraform.tf
+++ b/terraform/services/opt-out-import/terraform.tf
@@ -1,11 +1,11 @@
 provider "aws" {
   default_tags {
     tags = {
-      application = var.app_team
+      application = var.app
       business    = "oeda"
       code        = "https://github.com/CMSgov/ab2d-bcda-dpc-platform/tree/main/terraform/services/opt-out-import"
       component   = "opt-out-import"
-      environment = var.app_env
+      environment = var.env
       terraform   = true
     }
   }

--- a/terraform/services/opt-out-import/variables.tf
+++ b/terraform/services/opt-out-import/variables.tf
@@ -15,23 +15,3 @@ variable "app_env" {
     error_message = "Valid value for app_env is dev, test, sbx, or prod."
   }
 }
-
-variable "lambda_handler" {
-  description = "Lambda function handler"
-  type        = string
-}
-
-variable "lambda_runtime" {
-  description = "lambda function runtime"
-  type        = string
-}
-
-variable "bfd_bucket_role_arn" {
-  description = "ARN for the role to assume to access the BFD bucket"
-  type        = string
-}
-
-variable "bfd_sns_topic_arn" {
-  description = "ARN for the SNS topic set up by BFD to notify on file updates"
-  type        = string
-}

--- a/terraform/services/opt-out-import/variables.tf
+++ b/terraform/services/opt-out-import/variables.tf
@@ -1,17 +1,17 @@
-variable "app_team" {
-  description = "The application team (ab2d, bcda, dpc)"
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
   type        = string
   validation {
-    condition     = contains(["ab2d", "bcda", "dpc"], var.app_team)
-    error_message = "Valid value for app_team is ab2d, bcda, or dpc."
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
   }
 }
 
-variable "app_env" {
+variable "env" {
   description = "The application environment (dev, test, sbx, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "sbx", "prod"], var.app_env)
-    error_message = "Valid value for app_env is dev, test, sbx, or prod."
+    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, sbx, or prod."
   }
 }

--- a/terraform/services/tfstate/main.tf
+++ b/terraform/services/tfstate/main.tf
@@ -10,9 +10,13 @@ resource "aws_kms_alias" "this" {
   target_key_id = aws_kms_key.this.key_id
 }
 
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+}
+
 data "aws_iam_policy_document" "tls_only" {
   statement {
-    sid = "enforce-tls-requests-only"
+    sid = "AllowSSLRequestsOnly"
 
     effect = "Deny"
 
@@ -24,8 +28,8 @@ data "aws_iam_policy_document" "tls_only" {
     actions = ["s3:*"]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${var.name}",
-      "arn:${data.aws_partition.current.partition}:s3:::${var.name}/*"
+      aws_s3_bucket.this.arn,
+      "${aws_s3_bucket.this.arn}/*",
     ]
 
     condition {
@@ -34,10 +38,6 @@ data "aws_iam_policy_document" "tls_only" {
       values   = ["false"]
     }
   }
-}
-
-resource "aws_s3_bucket" "this" {
-  bucket = var.name
 }
 
 resource "aws_s3_bucket_policy" "this" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-176

## 🛠 Changes

Fixes for workflows and infra to get opt-out-import working as I roll it out across accounts and environments. As part of this work, I've also abstracted out a generic "terraform command" reusable workflow that places constraints on terraform workspaces it's used on. Most notably, they must only require "app" and "env" variables.

## ℹ️ Context for reviewers

Terraform has been successfully applied across AB2D, BCDA, and DPC environments. These are tweaks and refinements.

## ✅ Acceptance Validation

See workflow runs: https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/workflows/opt-out-import-apply.yml

## 🔒 Security Implications

None.