### PR TITLE
PLT-287 Add dead letter queue to queue module

### DIFF
--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -6,6 +6,10 @@ on:
       - main
     paths:
       - .github/workflows/opt-out-import-apply.yml
+      - terraform/modules/lambda/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
       - terraform/services/opt-out-import/**
   workflow_dispatch: # Allow manual trigger
 

--- a/.github/workflows/opt-out-import-plan.yml
+++ b/.github/workflows/opt-out-import-plan.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - .github/workflows/opt-out-import-plan.yml
+      - terraform/modules/lambda/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
       - terraform/services/opt-out-import/**
   workflow_dispatch: # Allow manual trigger
 

--- a/terraform/modules/lambda/main.tf
+++ b/terraform/modules/lambda/main.tf
@@ -170,7 +170,7 @@ module "vpc" {
 module "subnets" {
   source = "../subnets"
 
-  vpc_id = module.vpc.vpc_id
+  vpc_id = module.vpc.id
   app    = var.app
   layer  = "data"
 }
@@ -180,7 +180,7 @@ resource "aws_security_group" "lambda" {
 
   name        = "${var.function_name}-lambda"
   description = "For the ${var.function_name} lambda"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = module.vpc.id
 
   egress {
     from_port        = 0
@@ -206,7 +206,7 @@ resource "aws_lambda_function" "this" {
   }
 
   vpc_config {
-    subnet_ids         = module.subnets.subnet_ids
+    subnet_ids         = module.subnets.ids
     security_group_ids = length(var.security_group_ids) > 0 ? var.security_group_ids : [aws_security_group.lambda[0].id]
   }
 

--- a/terraform/modules/queue/main.tf
+++ b/terraform/modules/queue/main.tf
@@ -69,7 +69,7 @@ resource "aws_sqs_queue" "this" {
   })
 }
 
-resource "aws_sqs_queue_redrive_allow_policy" "terraform_queue_redrive_allow_policy" {
+resource "aws_sqs_queue_redrive_allow_policy" "this" {
   queue_url = aws_sqs_queue.dead_letter.id
 
   redrive_allow_policy = jsonencode({

--- a/terraform/modules/subnets/outputs.tf
+++ b/terraform/modules/subnets/outputs.tf
@@ -1,4 +1,4 @@
-output "subnet_ids" {
+output "ids" {
   description = "IDs of filtered subnets"
   value       = data.aws_subnets.this.ids
 }

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,4 +1,4 @@
-output "vpc_id" {
+output "id" {
   description = "ID of VPC"
   value       = data.aws_vpc.this.id
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-287

## 🛠 Changes

Added dead letter queue to the queue module.

## ℹ️ Context for reviewers

All standard SQS queues should have a dead letter queue to avoid endless retries of messages in the queue.

## ✅ Acceptance Validation

See checks for terraform plan.

## 🔒 Security Implications

None.
