### PR TITLE
PLT-337: Set hashicorp/setup-packer version to v2.0.1

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -52,7 +52,7 @@ jobs:
           echo "PKR_VAR_subnet_id=$SUBNET_ID" >> "$GITHUB_ENV"
 
       - name: Setup `packer`
-        uses: hashicorp/setup-packer@v2.0.1
+        uses: hashicorp/setup-packer@v2.0.0
         id: setup
         with:
           version: "latest"

--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -52,7 +52,7 @@ jobs:
           echo "PKR_VAR_subnet_id=$SUBNET_ID" >> "$GITHUB_ENV"
 
       - name: Setup `packer`
-        uses: hashicorp/setup-packer@main
+        uses: hashicorp/setup-packer@v2.0.1
         id: setup
         with:
           version: "latest"

--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -52,7 +52,7 @@ jobs:
           echo "PKR_VAR_subnet_id=$SUBNET_ID" >> "$GITHUB_ENV"
 
       - name: Setup `packer`
-        uses: hashicorp/setup-packer@v2.0.0
+        uses: hashicorp/setup-packer@v2.0.1
         id: setup
         with:
           version: "latest"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-337

## 🛠 Changes

Specifies the version to build on, since the newest version fails on a node20 error.

## ℹ️ Context for reviewers

Newest build of the Github Actions Runner AMIs failed, this should allow them to continue.

## ✅ Acceptance Validation

Build runs successfully.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
