### PR TITLE
PLT-292 Drop state mv commands from tfstate workflows

### DIFF
--- a/.github/workflows/tfstate-apply.yml
+++ b/.github/workflows/tfstate-apply.yml
@@ -34,19 +34,6 @@ jobs:
           role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
-      - run: |
-          terraform state mv aws_dynamodb_table.this module.tfstate_table.aws_dynamodb_table.this
-          terraform state mv aws_kms_alias.this module.tfstate_bucket.module.bucket_key.aws_kms_alias.this
-          terraform state mv aws_kms_key.this module.tfstate_bucket.module.bucket_key.aws_kms_key.this
-          terraform state mv aws_s3_bucket.logs module.tfstate_bucket.aws_s3_bucket.access_logs
-          terraform state mv aws_s3_bucket.this module.tfstate_bucket.aws_s3_bucket.this
-          terraform state mv aws_s3_bucket_logging.this module.tfstate_bucket.aws_s3_bucket_logging.this
-          terraform state mv aws_s3_bucket_policy.logs module.tfstate_bucket.aws_s3_bucket_policy.access_logs
-          terraform state mv aws_s3_bucket_policy.this module.tfstate_bucket.aws_s3_bucket_policy.this
-          terraform state mv aws_s3_bucket_server_side_encryption_configuration.logs module.tfstate_bucket.aws_s3_bucket_server_side_encryption_configuration.access_logs
-          terraform state mv aws_s3_bucket_server_side_encryption_configuration.this module.tfstate_bucket.aws_s3_bucket_server_side_encryption_configuration.this
-          terraform state mv aws_s3_bucket_versioning.logs module.tfstate_bucket.aws_s3_bucket_versioning.access_logs
-          terraform state mv aws_s3_bucket_versioning.this module.tfstate_bucket.aws_s3_bucket_versioning.this
       - run: terraform apply -auto-approve
         env:
           TF_VAR_app: ${{ matrix.app }}

--- a/.github/workflows/tfstate-plan.yml
+++ b/.github/workflows/tfstate-plan.yml
@@ -40,34 +40,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
-      # TODO remove these state mv commands following successful apply of changes in https://github.com/CMSgov/ab2d-bcda-dpc-platform/pull/51
-      - run: |
-          terraform state mv aws_dynamodb_table.this module.tfstate_table.aws_dynamodb_table.this
-          terraform state mv aws_kms_alias.this module.tfstate_bucket.module.bucket_key.aws_kms_alias.this
-          terraform state mv aws_kms_key.this module.tfstate_bucket.module.bucket_key.aws_kms_key.this
-          terraform state mv aws_s3_bucket.logs module.tfstate_bucket.aws_s3_bucket.access_logs
-          terraform state mv aws_s3_bucket.this module.tfstate_bucket.aws_s3_bucket.this
-          terraform state mv aws_s3_bucket_logging.this module.tfstate_bucket.aws_s3_bucket_logging.this
-          terraform state mv aws_s3_bucket_policy.logs module.tfstate_bucket.aws_s3_bucket_policy.access_logs
-          terraform state mv aws_s3_bucket_policy.this module.tfstate_bucket.aws_s3_bucket_policy.this
-          terraform state mv aws_s3_bucket_server_side_encryption_configuration.logs module.tfstate_bucket.aws_s3_bucket_server_side_encryption_configuration.access_logs
-          terraform state mv aws_s3_bucket_server_side_encryption_configuration.this module.tfstate_bucket.aws_s3_bucket_server_side_encryption_configuration.this
-          terraform state mv aws_s3_bucket_versioning.logs module.tfstate_bucket.aws_s3_bucket_versioning.access_logs
-          terraform state mv aws_s3_bucket_versioning.this module.tfstate_bucket.aws_s3_bucket_versioning.this
       - run: terraform plan
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - run: |
-          terraform state mv module.tfstate_table.aws_dynamodb_table.this aws_dynamodb_table.this
-          terraform state mv module.tfstate_bucket.module.bucket_key.aws_kms_alias.this aws_kms_alias.this
-          terraform state mv module.tfstate_bucket.module.bucket_key.aws_kms_key.this aws_kms_key.this
-          terraform state mv module.tfstate_bucket.aws_s3_bucket.access_logs aws_s3_bucket.logs
-          terraform state mv module.tfstate_bucket.aws_s3_bucket.this aws_s3_bucket.this
-          terraform state mv module.tfstate_bucket.aws_s3_bucket_logging.this aws_s3_bucket_logging.this
-          terraform state mv module.tfstate_bucket.aws_s3_bucket_policy.access_logs aws_s3_bucket_policy.logs
-          terraform state mv module.tfstate_bucket.aws_s3_bucket_policy.this aws_s3_bucket_policy.this
-          terraform state mv module.tfstate_bucket.aws_s3_bucket_server_side_encryption_configuration.access_logs aws_s3_bucket_server_side_encryption_configuration.logs
-          terraform state mv module.tfstate_bucket.aws_s3_bucket_server_side_encryption_configuration.this aws_s3_bucket_server_side_encryption_configuration.this
-          terraform state mv module.tfstate_bucket.aws_s3_bucket_versioning.access_logs aws_s3_bucket_versioning.logs
-          terraform state mv module.tfstate_bucket.aws_s3_bucket_versioning.this aws_s3_bucket_versioning.this


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-292

## 🛠 Changes

Dropped the `terraform state mv` commands from before and after the plan/apply in workflows.

## ℹ️ Context for reviewers

These commands did their job in allowing us to apply tfstate terraform without destroying and creating tfstate buckets, and now they can be removed.

## ✅ Acceptance Validation

Plan checks should be clean aside from a couple where the access log buckets couldn't be created due to a "TooManyBuckets" error. Those should apply without issue on merge.

## 🔒 Security Implications

None.
