### PR TITLE
PLT-321 Shared terraform for opt-out-export

### DIFF
--- a/.github/workflows/opt-out-export-apply.yml
+++ b/.github/workflows/opt-out-export-apply.yml
@@ -1,0 +1,41 @@
+name: opt-out-export apply terraform
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/opt-out-export-apply.yml
+      - terraform/modules/key/**
+      - terraform/modules/lambda/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/opt-out-export/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  terraform-apply:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/opt-out-export
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [ab2d, bcda, dpc]
+        env: [dev, test, sbx, prod]
+    env:
+      TF_VAR_app: ${{ matrix.app }}
+      TF_VAR_env: ${{ matrix.env }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
+      - run: terraform apply -auto-approve

--- a/.github/workflows/opt-out-export-plan.yml
+++ b/.github/workflows/opt-out-export-plan.yml
@@ -1,0 +1,47 @@
+name: opt-out-export plan terraform
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/opt-out-export-plan.yml
+      - terraform/modules/key/**
+      - terraform/modules/lambda/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/opt-out-export/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  check-terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/opt-out-export
+
+  terraform-plan:
+    needs: check-terraform-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/opt-out-export
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [ab2d, bcda, dpc]
+        env: [dev, test, sbx, prod]
+    env:
+      TF_VAR_app: ${{ matrix.app }}
+      TF_VAR_env: ${{ matrix.env }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
+      - run: terraform plan

--- a/terraform/services/opt-out-export/.terraform.lock.hcl
+++ b/terraform/services/opt-out-export/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.8.0"
+  constraints = "~> 5.8.0"
+  hashes = [
+    "h1:vnjWfeuf4AflWsRq3ivVig8dR8PAg8BHTVyAtOzJ1yQ=",
+    "zh:0974311d5e1becfdcbdae43d022d52689fdad32a4145659e56ac534bcb8cba02",
+    "zh:100dc64a90fc0d36cf6e2882b4358fde17705edd8ab3c5f2c06d219c36b21565",
+    "zh:467a86de8a7d77cde5c3386f9e82d7f1bf5972d1b3d177e797d1d9d2e87fd357",
+    "zh:4ad1f8ef5c5522f81d271b93594a43a7666b3409ca201a1911cd950e489ef12b",
+    "zh:540a50ab7061c6df2057ec9580890a9e86a687233120af738985fa84dde2a20a",
+    "zh:6e7b73b770e92891da94751c3e0cff1e1b852f5121da8c4a689056833eeb7d94",
+    "zh:879d42721e86331b05ff77bd219ca9a062485cdb2fa803d2dcf63084f25d484c",
+    "zh:980563e615fbba127c02df6dc8872ce60f7137df45fdb8cd801cdcbae6cf192a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6ad25c4d3edde466ea68731097aedad4b68278af0742fc1ab71d2c30491f92e",
+    "zh:af8df9e06f576c11ce67ac2b675d0d8db4aac618fec95d27c10aa59436feebbf",
+    "zh:b625ca7c4b99c6b3af34041b9773ccd9d80b0dde264c40b5d163a6abd73793af",
+    "zh:c9e0ca6aa48ebaa0892ac438392c49052a86605f490950d5317855f35ab7d74a",
+    "zh:dc500a03d3ed6b1fed3f118a55a7fb93bf172965ae6b2f25cc7f4a152e44edd7",
+    "zh:e0438bf67d93a29f0d56f9a4544297155ca85c0f10626778d4c3aa68c7e93581",
+  ]
+}

--- a/terraform/services/opt-out-export/README.md
+++ b/terraform/services/opt-out-export/README.md
@@ -1,0 +1,18 @@
+# Terraform for opt-out-export lambda
+
+This service sets up the infrastructure for the opt-out-export lambda in upper and lower environments for all teams.
+
+## Manual deploy
+
+Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
+
+```bash
+export TF_VAR_app=ab2d
+export TF_VAR_env=dev
+terraform init -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
+terraform apply
+```
+
+## Automated deploy
+
+This terraform is automatically applied on merge to main by the opt-out-export-apply.yml workflow.

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -1,0 +1,37 @@
+locals {
+  full_name = "${var.app}-${var.env}-opt-out-export"
+  bfd_env = var.env == "prod" ? "prod" : "test"
+}
+
+data "aws_ssm_parameter" "bfd_account" {
+  name = "/bfd/account-id"
+}
+
+data "aws_iam_policy_document" "assume_bucket_role" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::${data.aws_ssm_parameter.bfd_account.value}:role/bfd-${local.bfd_env}-eft-${var.app}-bucket-role"]
+  }
+}
+
+module "opt_out_export_lambda" {
+  source = "../../modules/lambda"
+
+  app = var.app
+  env = var.env
+
+  function_name        = local.full_name
+  function_description = "Outputs data attribution to BFD"
+
+  handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"
+  runtime = var.app == "ab2d" ? "java11" : "provided.al2"
+
+  lambda_role_inline_policies = {
+    assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json
+  }
+
+  environment_variables = {
+    ENV      = var.env
+    APP_NAME = "${var.app}-${var.env}-opt-out-export"
+  }
+}

--- a/terraform/services/opt-out-export/outputs.tf
+++ b/terraform/services/opt-out-export/outputs.tf
@@ -1,0 +1,7 @@
+output "lambda_role_arn" {
+  value = module.opt_out_export_lambda.role_arn
+}
+
+output "zip_bucket" {
+  value = module.opt_out_export_lambda.zip_bucket
+}

--- a/terraform/services/opt-out-export/terraform.tf
+++ b/terraform/services/opt-out-export/terraform.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      application = var.app
+      business    = "oeda"
+      code        = "https://github.com/CMSgov/ab2d-bcda-dpc-platform/tree/main/terraform/services/opt-out-export"
+      component   = "opt-out-export"
+      environment = var.env
+      terraform   = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "opt-out-export/terraform.tfstate"
+  }
+}

--- a/terraform/services/opt-out-export/variables.tf
+++ b/terraform/services/opt-out-export/variables.tf
@@ -1,0 +1,17 @@
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
+  type        = string
+  validation {
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, sbx, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, sbx, or prod."
+  }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-321

## 🛠 Changes

Added terraform and workflows for opt-out-export infrastructure.

## ℹ️ Context for reviewers

Very similar to opt-out-import but without an SQS queue since it won't be receiving messages from BFD.

## ✅ Acceptance Validation

See plans in checks.

## 🔒 Security Implications

None.
