### PR TITLE
PLT-321 Default timeout to lambda max

### DIFF
--- a/terraform/modules/function/variables.tf
+++ b/terraform/modules/function/variables.tf
@@ -41,7 +41,7 @@ variable "runtime" {
 variable "timeout" {
   description = "Lambda function timeout"
   type        = number
-  default     = null
+  default     = 900
 }
 
 variable "function_role_inline_policies" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-321

## 🛠 Changes

Set default for function timeout to 900 seconds, the max for lambda, rather than the built-in default of 3 seconds.

## ℹ️ Context for reviewers

In testing opt-out-import and opt-out-export, engineers have requested this setting.

## ✅ Acceptance Validation

See checks.

## 🔒 Security Implications

None.
