### PR TITLE
PLT-321: Add ssm:GetParameter permissions to lambdas

### DIFF
--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -103,6 +103,7 @@ data "aws_iam_policy_document" "function_inline" {
       "sqs:DeleteMessage",
       "sqs:GetQueueAttributes",
       "sqs:ReceiveMessage",
+      "ssm:GetParameter",
       "ssm:GetParameters",
     ]
     resources = ["*"]


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-321

## 🛠 Changes

- Allow retrieval of single parameters for lambda

## ℹ️ Context for reviewers

The updated lambda in https://github.com/CMSgov/dpc-app/pull/2055 pulls the assume-role-arn as a single parameter from SSM. This adds the permission to retrieve a single parameter.

## ✅ Acceptance Validation

Made this change manually and was able to confirm successful lambda run.

## 🔒 Security Implications

Since this is a subset of the existing permissions (ssm:GetParamters), no real changes in security control/boundary here.

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.
