### PR TITLE
PLT-362 Set function memory for ab2d

### DIFF
--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -205,6 +205,7 @@ resource "aws_lambda_function" "this" {
   handler       = var.handler
   runtime       = var.runtime
   timeout       = var.timeout
+  memory_size   = var.memory_size
 
   tracing_config {
     mode = "Active"

--- a/terraform/modules/function/variables.tf
+++ b/terraform/modules/function/variables.tf
@@ -44,6 +44,12 @@ variable "timeout" {
   default     = 900
 }
 
+variable "memory_size" {
+  description = "Lambda function memory size"
+  type        = number
+  default     = null
+}
+
 variable "function_role_inline_policies" {
   description = "Inline policies (in JSON) for the function IAM role"
   type        = map(string)

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -51,7 +51,7 @@ module "opt_out_export_function" {
   handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"
   runtime = var.app == "ab2d" ? "java11" : "provided.al2"
 
-  memory_size = locals.memory_size[var.app]
+  memory_size = local.memory_size[var.app]
 
   function_role_inline_policies = {
     assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -17,6 +17,11 @@ locals {
     bcda = var.env == "sbx" ? "bcda-opensbx-rds" : "bcda-${var.env}-rds"
     dpc  = var.env == "sbx" ? "dpc-prod-sbx-db" : "dpc-${var.env}-db"
   }
+  memory_size = {
+    ab2d = 1024
+    bcda = null
+    dpc  = null
+  }
 }
 
 data "aws_ssm_parameter" "bfd_account" {
@@ -45,6 +50,8 @@ module "opt_out_export_function" {
 
   handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"
   runtime = var.app == "ab2d" ? "java11" : "provided.al2"
+
+  memory_size = locals.memory_size[var.app]
 
   function_role_inline_policies = {
     assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -45,7 +45,7 @@ module "opt_out_import_function" {
   handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"
   runtime = var.app == "ab2d" ? "java11" : "provided.al2"
 
-  memory_size = locals.memory_size[var.app]
+  memory_size = local.memory_size[var.app]
 
   function_role_inline_policies = {
     assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -11,6 +11,11 @@ locals {
     bcda = var.env == "sbx" ? "bcda-opensbx-rds" : "bcda-${var.env}-rds"
     dpc  = var.env == "sbx" ? "dpc-prod-sbx-db" : "dpc-${var.env}-db"
   }
+  memory_size = {
+    ab2d = 2048
+    bcda = null
+    dpc  = null
+  }
 }
 
 data "aws_ssm_parameter" "bfd_bucket_role_arn" {
@@ -39,6 +44,8 @@ module "opt_out_import_function" {
 
   handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"
   runtime = var.app == "ab2d" ? "java11" : "provided.al2"
+
+  memory_size = locals.memory_size[var.app]
 
   function_role_inline_policies = {
     assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-362

## 🛠 Changes

Set memory limit for the opt-out lambda functions as requested in PLT-362 for AB2D: 1GB for export, 2GB for import

## ℹ️ Context for reviewers

This should allow for easy adjustment of the memory size limit for DPC and BCDA as well.

## ✅ Acceptance Validation

See checks.

## 🔒 Security Implications

None.
