### PR TITLE
PLT-362 Allow assume of lambda role in prod

### DIFF
--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -32,46 +32,40 @@ data "aws_iam_policy_document" "function_assume_role" {
   }
 
   # Allow access from GitHub-hosted runners via OIDC for integration tests
-  dynamic "statement" {
-    for_each = var.env != "prod" ? [1] : []
-    content {
-      actions = [
-        "sts:AssumeRoleWithWebIdentity",
-        "sts:TagSession",
-      ]
+  statement {
+    actions = [
+      "sts:AssumeRoleWithWebIdentity",
+      "sts:TagSession",
+    ]
 
-      principals {
-        type        = "Federated"
-        identifiers = [data.aws_iam_openid_connect_provider.github.arn]
-      }
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
 
-      condition {
-        test     = "StringEquals"
-        variable = "${local.provider_domain}:aud"
-        values   = ["sts.amazonaws.com"]
-      }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.provider_domain}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
 
-      condition {
-        test     = "StringLike"
-        variable = "${local.provider_domain}:sub"
-        values   = local.repos[var.app]
-      }
+    condition {
+      test     = "StringLike"
+      variable = "${local.provider_domain}:sub"
+      values   = local.repos[var.app]
     }
   }
 
   # Allow access from admin role for manual checks
-  dynamic "statement" {
-    for_each = var.env != "prod" ? [1] : []
-    content {
-      actions = [
-        "sts:AssumeRole",
-        "sts:TagSession",
-      ]
+  statement {
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
 
-      principals {
-        type        = "AWS"
-        identifiers = [data.aws_iam_role.admin.arn]
-      }
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_iam_role.admin.arn]
     }
   }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-362

## 🛠 Changes

Remove conditional to allow assumption of lambda roles in prod.

## ℹ️ Context for reviewers

Given the need to check configuration and smoke test in prod, the role policy has been updated to allow admin and GitHub roles to assume the lambda role.

## ✅ Acceptance Validation

See plans in checks.

## 🔒 Security Implications

None.
