### PR TITLE
DPC-3952: Increase DPC export lambda memory

### DIFF
--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -20,7 +20,7 @@ locals {
   memory_size = {
     ab2d = 1024
     bcda = null
-    dpc  = null
+    dpc  = 1024
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3952

## 🛠 Changes

- Update memory for DPC export lambda

## ℹ️ Context for reviewers

Tested with 128GB and the lambda stalled out while reading data from the database. After increasing the memory manually, was able to run the lambda successfully.

Looks like it currently requires 700MB, but would prefer to bump that to avoid issues in the future when DPC onboarding comes back online.

I think we will eventually want to improve the memory usage of our lambda — comparing with AB2D, we have significantly less data but are using comparable memory. Likely because we are loading all the data from the DB into Go structs, and then copying them into a byte buffer for writing to S3.

## ✅ Acceptance Validation

![CleanShot 2024-03-15 at 15 49 10@2x](https://github.com/CMSgov/ab2d-bcda-dpc-platform/assets/2308368/eb808fbd-88a3-4ae9-b918-3cfff407b604)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
