### PR TITLE
PLT-362 Give AB2D export function max memory

### DIFF
--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -18,7 +18,7 @@ locals {
     dpc  = var.env == "sbx" ? "dpc-prod-sbx-db" : "dpc-${var.env}-db"
   }
   memory_size = {
-    ab2d = 1024
+    ab2d = 10240
     bcda = null
     dpc  = 1024
   }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-362

## 🛠 Changes

Set ab2d opt-out lambda function to max memory (10GB).

## ℹ️ Context for reviewers

AB2D export function currently uses a little under 5GB and runs for 28.6 seconds, but that may grow. Even at 10GB memory, running for 28.6 seconds costs approximately $0.00477, so cost concerns are low. We can adjust downward once usage is more established.

<img width="543" alt="Screenshot 2024-03-15 at 4 42 58 PM" src="https://github.com/CMSgov/ab2d-bcda-dpc-platform/assets/151913/14bb25b6-27dd-4749-ac0a-17f8738cd72c">

## ✅ Acceptance Validation

See checks.

## 🔒 Security Implications

None.
