### PR TITLE
PLT-390 Add access to key for cross-account roles

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -2,6 +2,8 @@ module "bucket_key" {
   source      = "../key"
   name        = "${var.name}-bucket"
   description = "For ${var.name} S3 bucket and its access logs"
+
+  additional_access_roles = var.cross_account_read_roles
 }
 
 resource "aws_s3_bucket" "this" {

--- a/terraform/modules/key/main.tf
+++ b/terraform/modules/key/main.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "this" {
       type = "AWS"
       identifiers = concat(
         ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"],
-        var.additional_access_roles
+        var.additional_access_roles,
       )
     }
   }

--- a/terraform/modules/key/main.tf
+++ b/terraform/modules/key/main.tf
@@ -21,8 +21,11 @@ data "aws_iam_policy_document" "this" {
     resources = ["*"]
 
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      type = "AWS"
+      identifiers = concat(
+        ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"],
+        var.additional_access_roles
+      )
     }
   }
 

--- a/terraform/modules/key/variables.tf
+++ b/terraform/modules/key/variables.tf
@@ -20,3 +20,9 @@ variable "buckets" {
   type        = list
   default     = []
 }
+
+variable "additional_access_roles" {
+  description = "ARNs for additional roles that need access to this key"
+  type        = list
+  default     = []
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-390

## 🛠 Changes

Added access to the KMS key for cross-account read roles on S3 buckets.

## ℹ️ Context for reviewers

Without this key access, promotion of function code was failing for AB2D: https://github.com/CMSgov/ab2d-lambdas/actions/runs/8426183564

## ✅ Acceptance Validation

Applied in ab2d-test environment and promotion now succeeds: https://github.com/CMSgov/ab2d-lambdas/actions/runs/8457881223

## 🔒 Security Implications

None.
