### PR TITLE
PLT-390 Allow admin to assume github actions role

### DIFF
--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -1,6 +1,5 @@
 locals {
   provider_domain = "token.actions.githubusercontent.com"
-  admin_app = var.app == "dpc" ? "bcda" : var.app
   repos = {
     ab2d = [
       "repo:CMSgov/ab2d-bcda-dpc-platform:*",
@@ -17,6 +16,7 @@ locals {
       "repo:CMSgov/dpc-app:*",
     ]
   }
+  admin_app = var.app == "dpc" ? "bcda" : var.app
 }
 
 data "aws_iam_openid_connect_provider" "github" {
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "github_actions_role_assume" {
     ]
 
     principals {
-      type        = "AWS"
+      type = "AWS"
       identifiers = [
         data.aws_ssm_parameter.github_runner_role_arn.value,
         data.aws_iam_role.admin.arn,


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-390

## 🛠 Changes

Allow the ct-ado admin role in each account to assume the GitHub Actions role we use for deploys.

## ℹ️ Context for reviewers

In troubleshooting permissions for PLT-390 I found it quite useful to be able to assume the GitHub Actions role.

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

None.
