### PR TITLE
PLT-383 Drop sbx env from opt-out workflows

### DIFF
--- a/.github/workflows/opt-out-export-apply.yml
+++ b/.github/workflows/opt-out-export-apply.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
-        env: [dev, test, sbx, prod]
+        env: [dev, test, prod]
     env:
       TF_VAR_app: ${{ matrix.app }}
       TF_VAR_env: ${{ matrix.env }}

--- a/.github/workflows/opt-out-export-plan.yml
+++ b/.github/workflows/opt-out-export-plan.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
-        env: [dev, test, sbx, prod]
+        env: [dev, test, prod]
     env:
       TF_VAR_app: ${{ matrix.app }}
       TF_VAR_env: ${{ matrix.env }}

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
-        env: [dev, test, sbx, prod]
+        env: [dev, test, prod]
     env:
       TF_VAR_app: ${{ matrix.app }}
       TF_VAR_env: ${{ matrix.env }}

--- a/.github/workflows/opt-out-import-plan.yml
+++ b/.github/workflows/opt-out-import-plan.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
-        env: [dev, test, sbx, prod]
+        env: [dev, test, prod]
     env:
       TF_VAR_app: ${{ matrix.app }}
       TF_VAR_env: ${{ matrix.env }}

--- a/.github/workflows/opt-out-test-apply.yml
+++ b/.github/workflows/opt-out-test-apply.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
-        env: [dev, test, sbx, prod]
+        env: [dev, test, prod]
     env:
       TF_VAR_app: ${{ matrix.app }}
       TF_VAR_env: ${{ matrix.env }}

--- a/.github/workflows/opt-out-test-plan.yml
+++ b/.github/workflows/opt-out-test-plan.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
-        env: [dev, test, sbx, prod]
+        env: [dev, test, prod]
     env:
       TF_VAR_app: ${{ matrix.app }}
       TF_VAR_env: ${{ matrix.env }}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-383

## 🛠 Changes

Dropped the sbx env across opt-out workflows.

## ℹ️ Context for reviewers

In discussions with the application teams I confirmed there's no need for opt-out infrastructure in the sandbox environments.

## ✅ Acceptance Validation

This change will just keep future merges from applying in the sandbox environments. I'll destroy infra in these environments, then drop sbx-specific configuration from the terraform once this is merged.

## 🔒 Security Implications

None.
