### PR TITLE
PLT-383 Remove sbx config from opt-out

### DIFF
--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -11,13 +11,12 @@ locals {
   ab2d_db_envs = {
     dev  = "dev"
     test = "east-impl"
-    sbx  = "sbx-sandbox"
     prod = "east-prod"
   }
   db_sg_name = {
     ab2d = "ab2d-${local.ab2d_db_envs[var.env]}-database-sg"
-    bcda = var.env == "sbx" ? "bcda-opensbx-rds" : "bcda-${var.env}-rds"
-    dpc  = var.env == "sbx" ? "dpc-prod-sbx-db" : "dpc-${var.env}-db"
+    bcda = "bcda-${var.env}-rds"
+    dpc  = "dpc-${var.env}-db"
   }
   memory_size = {
     ab2d = 10240

--- a/terraform/services/opt-out-export/variables.tf
+++ b/terraform/services/opt-out-export/variables.tf
@@ -8,10 +8,10 @@ variable "app" {
 }
 
 variable "env" {
-  description = "The application environment (dev, test, sbx, prod)"
+  description = "The application environment (dev, test, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
-    error_message = "Valid value for env is dev, test, sbx, or prod."
+    condition     = contains(["dev", "test", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, or prod."
   }
 }

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -3,13 +3,12 @@ locals {
   ab2d_db_envs = {
     dev  = "dev"
     test = "east-impl"
-    sbx  = "sbx-sandbox"
     prod = "east-prod"
   }
   db_sg_name = {
     ab2d = "ab2d-${local.ab2d_db_envs[var.env]}-database-sg"
-    bcda = var.env == "sbx" ? "bcda-opensbx-rds" : "bcda-${var.env}-rds"
-    dpc  = var.env == "sbx" ? "dpc-prod-sbx-db" : "dpc-${var.env}-db"
+    bcda = "bcda-${var.env}-rds"
+    dpc  = "dpc-${var.env}-db"
   }
   memory_size = {
     ab2d = 2048

--- a/terraform/services/opt-out-import/variables.tf
+++ b/terraform/services/opt-out-import/variables.tf
@@ -8,10 +8,10 @@ variable "app" {
 }
 
 variable "env" {
-  description = "The application environment (dev, test, sbx, prod)"
+  description = "The application environment (dev, test, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
-    error_message = "Valid value for env is dev, test, sbx, or prod."
+    condition     = contains(["dev", "test", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, or prod."
   }
 }

--- a/terraform/services/opt-out-test/variables.tf
+++ b/terraform/services/opt-out-test/variables.tf
@@ -8,10 +8,10 @@ variable "app" {
 }
 
 variable "env" {
-  description = "The application environment (dev, test, sbx, prod)"
+  description = "The application environment (dev, test, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
-    error_message = "Valid value for env is dev, test, sbx, or prod."
+    condition     = contains(["dev", "test", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, or prod."
   }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-383

## 🛠 Changes

Configuration specific to the sbx (sandbox) environment was removed from opt-out terraform.

## ℹ️ Context for reviewers

The opt-out lambdas are not deployed to the sandbox environment, so configuration specific to that environment is not needed.

## ✅ Acceptance Validation

See checks, should be no change in terraform plan.

## 🔒 Security Implications

None.
