### PR TITLE
Increase runner hop limit to 2

### DIFF
--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -16,7 +16,7 @@ build {
   provisioner "shell" {
     environment_vars = []
     inline = concat([
-      "sudo yum -y upgrade-minimal",
+      "sudo yum -y update --security",
       "sudo yum -y install amazon-cloudwatch-agent jq git docker",
       "sudo yum -y install curl",
       "sudo systemctl enable docker.service",

--- a/packer/github-actions-runner/sources.pkr.hcl
+++ b/packer/github-actions-runner/sources.pkr.hcl
@@ -29,7 +29,7 @@ source "amazon-ebs" "github-actions-runner" {
   metadata_options {
     http_endpoint = "enabled"
     http_tokens = "required"
-    http_put_response_hop_limit = 1
+    http_put_response_hop_limit = 2
   }
   # enforces IMDSv2 support on the resulting AMI
   imds_support = "v2.0"


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

Upped hop limit on the runner from 1 to 2.

## ℹ️ Context for reviewers

Preemptively addressing this having seen the issue at https://github.com/philips-labs/terraform-aws-github-runner/issues/3821, which states that `http_put_response_hop_limit` must be increased to 2 for containers to access the instance metadata and access credentials for the instance profile.

## ✅ Acceptance Validation

See checks for image build.

## 🔒 Security Implications

None.
