### PR TITLE
Set pipefail on assume-role script

### DIFF
--- a/scripts/aws-assume-role.sh
+++ b/scripts/aws-assume-role.sh
@@ -1,6 +1,8 @@
 # shellcheck shell=sh
 # Start AWS session for MFA-enabled account
 
+set -o pipefail
+
 # https://stackoverflow.com/questions/61784326/zsh-bash-source-command-behavior-difference
 # shellcheck disable=SC2128,SC3028
 if { [ -n "$BASH_VERSION" ] && [ "$BASH_SOURCE" = "$0" ]; } ||
@@ -20,6 +22,7 @@ fi
 tmpfile=$(mktemp)
 
 cleanup() {
+  set +o pipefail
   rm "$tmpfile"
 }
 


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

Added pipefail option in aws-assume-role.sh script.

## ℹ️ Context for reviewers

Errors from "aws sts assume-role" command in the script will now halt execution.

## ✅ Acceptance Validation

Tested locally.

## 🔒 Security Implications

None.
