### PR TITLE
PLT-400 Lower ab2d opt-out-import mem to 1G

### DIFF
--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -11,7 +11,7 @@ locals {
     dpc  = "dpc-${var.env}-db"
   }
   memory_size = {
-    ab2d = 2048
+    ab2d = 1024
     bcda = null
     dpc  = null
   }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-400

## 🛠 Changes

Lowered ab2d opt-out-import memory to 1GB.

## ℹ️ Context for reviewers

In reviewing runs of the import function, memory peaks at roughly 250MB. My conclusion from research is that the JVM heap defaults to 25% of 1GB for machines with 1GB or more memory. We should therefore be able to change the memory from 2GB to 1GB with no effect on the function resources.

## ✅ Acceptance Validation

See checks for plan.

## 🔒 Security Implications

None.
