### PR TITLE
PLT-469 Update pull request template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,18 +2,18 @@
 
 The following expectations apply to each PR our internal teams file:
 
-- The PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name).
-- Reviewers are selected to include people from all teams impacted by the changes in the PR.
-- The PR has been assigned to the people who will respond to reviews and merge when ready (usually the person filing the review, but can change when a PR is handed off to someone else).
-- The PR is reasonably limited in scope to ensure:
+1. The PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name).
+2. Reviewers are selected to include people from all teams impacted by the changes in the PR.
+3. The PR has been assigned to the people who will respond to reviews and merge when ready (usually the person filing the review, but can change when a PR is handed off to someone else).
+4. The PR is reasonably limited in scope to ensure:
   - It doesn't bunch together disparate features, fixes, refactorings, etc.
   - There isn't too much of a burden on reviewers.
   - Any problems it causes have a small blast radius.
   - Changes will be easier to roll back if necessary.
-- The PR includes any required documentation changes, including `README` updates and changelog or release notes entries.
-- All new and modified code is appropriately commented to make the what and why of its design reasonably clear, even to those unfamiliar with the project.
-- Any incomplete work introduced by the PR is detailed in `TODO` comments which include a JIRA ticket ID for any items that require urgent attention.
-- If any of the following security implications apply, the PR must not be merged without Stephen Walter's approval. Note any security implications in the Context section of the PR description and add Stephen Walter (GitHub username: SJWalter11) as a reviewer.
+5. The PR includes any required documentation changes, including `README` updates and changelog or release notes entries.
+6. All new and modified code is appropriately commented to make the what and why of its design reasonably clear, even to those unfamiliar with the project.
+7. Any incomplete work introduced by the PR is detailed in `TODO` comments which include a JIRA ticket ID for any items that require urgent attention.
+8. If any of the following security implications apply, the PR must not be merged without Stephen Walter's approval. Note any security implications in the Context section of the PR description and add Stephen Walter (GitHub username: SJWalter11) as a reviewer.
   - Adds a new software dependency or dependencies.
   - Modifies or invalidates one or more of our security controls.
   - Stores or transmits data that was not stored or transmitted before.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contribution expectations
+
+The following expectations apply to each PR our internal teams file:
+
+- The PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name).
+- Reviewers are selected to include people from all teams impacted by the changes in the PR.
+- The PR has been assigned to the people who will respond to reviews and merge when ready (usually the person filing the review, but can change when a PR is handed off to someone else).
+- The PR is reasonably limited in scope to ensure:
+  - It doesn't bunch together disparate features, fixes, refactorings, etc.
+  - There isn't too much of a burden on reviewers.
+  - Any problems it causes have a small blast radius.
+  - Changes will be easier to roll back if necessary.
+- The PR includes any required documentation changes, including `README` updates and changelog or release notes entries.
+- All new and modified code is appropriately commented to make the what and why of its design reasonably clear, even to those unfamiliar with the project.
+- Any incomplete work introduced by the PR is detailed in `TODO` comments which include a JIRA ticket ID for any items that require urgent attention.
+- If any of the following security implications apply, the PR must not be merged without Stephen Walter's approval. Note any security implications in the Context section of the PR description and add Stephen Walter (GitHub username: SJWalter11) as a reviewer.
+  - Adds a new software dependency or dependencies.
+  - Modifies or invalidates one or more of our security controls.
+  - Stores or transmits data that was not stored or transmitted before.
+  - Requires additional review of security implications for other reasons.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution expectations
 
-The following expectations apply to each PR our internal teams file:
+The following expectations apply to each PR in our internal teams file:
 
 1. The PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name).
 2. Reviewers are selected to include people from all teams impacted by the changes in the PR.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,15 +6,15 @@ The following expectations apply to each PR our internal teams file:
 2. Reviewers are selected to include people from all teams impacted by the changes in the PR.
 3. The PR has been assigned to the people who will respond to reviews and merge when ready (usually the person filing the review, but can change when a PR is handed off to someone else).
 4. The PR is reasonably limited in scope to ensure:
-  - It doesn't bunch together disparate features, fixes, refactorings, etc.
-  - There isn't too much of a burden on reviewers.
-  - Any problems it causes have a small blast radius.
-  - Changes will be easier to roll back if necessary.
+   - It doesn't bunch together disparate features, fixes, refactorings, etc.
+   - There isn't too much of a burden on reviewers.
+   - Any problems it causes have a small blast radius.
+   - Changes will be easier to roll back if necessary.
 5. The PR includes any required documentation changes, including `README` updates and changelog or release notes entries.
 6. All new and modified code is appropriately commented to make the what and why of its design reasonably clear, even to those unfamiliar with the project.
 7. Any incomplete work introduced by the PR is detailed in `TODO` comments which include a JIRA ticket ID for any items that require urgent attention.
 8. If any of the following security implications apply, the PR must not be merged without Stephen Walter's approval. Note any security implications in the Context section of the PR description and add Stephen Walter (GitHub username: SJWalter11) as a reviewer.
-  - Adds a new software dependency or dependencies.
-  - Modifies or invalidates one or more of our security controls.
-  - Stores or transmits data that was not stored or transmitted before.
-  - Requires additional review of security implications for other reasons.
+   - Adds a new software dependency or dependencies.
+   - Modifies or invalidates one or more of our security controls.
+   - Stores or transmits data that was not stored or transmitted before.
+   - Requires additional review of security implications for other reasons.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,22 +13,3 @@ https://jira.cms.gov/browse/***
 ## 🧪 Validation
 
 <!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
-
-## ✅ Checklist
-
-- [ ] This PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name).
-- [ ] Reviewers have been selected to include people from all teams impacted by these changes.
-- [ ] This PR has been assigned to the people who will respond to reviews and merge when ready (usually the person filing the review, but can change when a PR is handed off to someone else).
-- [ ] This PR is reasonably limited in scope to ensure:
-  - It doesn't bunch together disparate features, fixes, refactorings, etc.
-  - There isn't too much of a burden on reviewers.
-  - Any problems it causes have a small blast radius.
-  - Changes will be easier to roll back if necessary.
-- [ ] This PR includes any required documentation changes, including `README` updates and changelog or release notes entries.
-- [ ] All new and modified code is appropriately commented to make the what and why of its design reasonably clear, even to those unfamiliar with the project.
-- [ ] Any incomplete work introduced by this PR is detailed in `TODO` comments which include a JIRA ticket ID for any items that require urgent attention.
-- [ ] This PR has no security implications, or if any of the following apply, they have been noted in the Context section above, Stephen Walter (GitHub username: SJWalter11) has been added as a reviewer, and this PR will not be merged without Stephen's approval:
-  - Adds a new software dependency or dependencies.
-  - Modifies or invalidates one or more of our security controls.
-  - Stores or transmits data that was not stored or transmitted before.
-  - Requires additional review of security implications for other reasons.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,32 @@
 ## 🎫 Ticket
 
-https://jira.cms.gov/browse/xxx
+https://jira.cms.gov/browse/***
 
 ## 🛠 Changes
 
-(What was added, updated, or removed in this PR.)
+<!-- What was added, updated, or removed in this PR? -->
 
-## ℹ️ Context for reviewers
+## ℹ️ Context
 
-(Background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.)
+<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
 
-## ✅ Acceptance Validation
+## 🧪 Validation
 
-(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)
+<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 
-## 🔒 Security Implications
+## ✅ Checklist
 
-- [ ] This PR adds a new software dependency or dependencies.
-- [ ] This PR modifies or invalidates one or more of our security controls.
-- [ ] This PR stores or transmits data that was not stored or transmitted before.
-- [ ] This PR requires additional review of its security implications for other reasons.
-
-If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
+- [ ] This PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name)
+- [ ] This PR is reasonably limited in scope to ensure:
+  - It doesn't bunch together disparate features, fixes, refactorings, etc.
+  - There isn't too much of a burden on reviewers.
+  - Any problems it causes have a small blast radius.
+  - Changes will be easier to roll back if necessary.
+- [ ] This PR includes any required documentation changes, including `README` updates and changelog or release notes entries.
+- [ ] All new and modified code is appropriately commented to make the what and why of its design reasonably clear, even to those unfamiliar with the project.
+- [ ] Any incomplete work introduced by this PR is detailed in `TODO` comments which include a JIRA ticket ID for any items that require urgent attention.
+- [ ] This PR has no security implications, or if any of the following apply, they have been noted in the Context section above, Stephen Walter (GitHub username: SJWalter11) has been added as a reviewer, and this PR will not be merged without Stephen's approval:
+  - Adds a new software dependency or dependencies.
+  - Modifies or invalidates one or more of our security controls.
+  - Stores or transmits data that was not stored or transmitted before.
+  - Requires additional review of security implications for other reasons.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,9 @@ https://jira.cms.gov/browse/***
 
 ## ✅ Checklist
 
-- [ ] This PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name)
+- [ ] This PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name).
+- [ ] Reviewers have been selected to include people from all teams impacted by these changes.
+- [ ] This PR has been assigned to the people who will respond to reviews and merge when ready (usually the person filing the review, but can change when a PR is handed off to someone else).
 - [ ] This PR is reasonably limited in scope to ensure:
   - It doesn't bunch together disparate features, fixes, refactorings, etc.
   - There isn't too much of a burden on reviewers.


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-469

## 🛠 Changes

Updated the PR template.

## ℹ️ Context

We need to update PRs across the program for Jason's rolloff, and I'm taking advantage of the general update to address a few issues I've seen in our PRs:

1. People are skipping sections. These prompts may lessen that by more directly engaging the person filing the PR with questions.
2. People are leaving default text in PRs. Prompts are now in comments to avoid displaying default text.
3. The multiple-choice "Security Implications" section made it look like PRs were being merged with unfinished tasks. This update drops the "Security Implications" section and adds a CONTRIBUTING doc with some items borrowed from the [BFD template](https://github.com/CMSgov/beneficiary-fhir-data/blob/6a2c431592fbf385e115a738d4c43173c3a8fdbe/.github/pull_request_template.md). 

In a kind of meta move, I'm using the new template for this PR description. Once this PR is approved, we'll roll out the same template across our program repos.

@Sadibhatla @kyeah I've added you as reviewers to check whether you have any concerns in using this template for your team repos.

@mjburling I've added you as a reviewer for any insights you've gathered around usage of the BFD template.

@SJWalter11 I've added you as a reviewer to get your approval on the security implications language.

## 🧪 Validation

Acceptance criteria will be met as long as the security reviewer is updated to Stephen and we get approval from relevant parties on this PR.