### PR TITLE
PLT-176 Drop outdated comment

### DIFF
--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -33,9 +33,6 @@ data "aws_iam_policy_document" "runner" {
   }
 }
 
-# Due to the developer-boundary-policy permissions boundary, this policy cannot be created by
-# the deploy role. The "terraform apply" to create it must be run by a login role with the
-# ct-ado-poweruser-permissions-boundary-policy permissions boundary.
 resource "aws_iam_policy" "runner" {
   name = "github-actions-runner"
   path = "/delegatedadmin/developer/"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-176

## 🛠 Changes

Dropped comment referring to inability of deploy role to create the runner role.

## ℹ️ Context for reviewers

With changes in #46 we codified the work the CMS Cloud support team had done for us in https://jiraent.cms.gov/browse/CLDSPT-60364 to assign the poweruser permissions boundary to the github action "deploy" roles. The comment that was removed is no longer true.

## ✅ Acceptance Validation

No acceptance validation, just documentation cleanup.

## 🔒 Security Implications

None.
