### PR TITLE
BCDA-8105 Add cclf-import terraform infrastructure 

### DIFF
--- a/.github/workflows/cclf-import-apply.yml
+++ b/.github/workflows/cclf-import-apply.yml
@@ -1,0 +1,44 @@
+name: cclf-import apply terraform
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/cclf-import-apply.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/cclf-import/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  terraform-apply:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/cclf-import
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [bcda]
+        env: [dev, test, prod]
+    env:
+      TF_VAR_app: ${{ matrix.app }}
+      TF_VAR_env: ${{ matrix.env }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'bcda' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
+      - run: terraform apply -auto-approve
+

--- a/.github/workflows/cclf-import-plan.yml
+++ b/.github/workflows/cclf-import-plan.yml
@@ -1,0 +1,49 @@
+name: cclf-import plan terraform
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/cclf-import-plan.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/cclf-import/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  check-terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/cclf-import
+
+  terraform-plan:
+    needs: check-terraform-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/cclf-import
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [bcda]
+        env: [dev, test, prod]
+    env:
+      TF_VAR_app: ${{ matrix.app }}
+      TF_VAR_env: ${{ matrix.env }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
+      - run: terraform plan

--- a/terraform/services/cclf-import/README.md
+++ b/terraform/services/cclf-import/README.md
@@ -1,0 +1,16 @@
+# Terraform for cclf-import function and associated infra
+
+This service sets up the infrastructure for the cclf-import lambda function in upper and lower environments for BCDA.
+
+## Manual deploy
+
+Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
+
+```bash
+terraform init -backend-config=../../backends/ab2d-dev.s3.tfbackend
+terraform apply
+```
+
+## Automated deploy
+
+This terraform is automatically applied on merge to main by the cclf-import-apply.yml workflow.

--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -49,7 +49,7 @@ module "cclf_import_function" {
   environment_variables = {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-cclf-import"
-    DB_HOST  = data.aws_ssm_parameter.cclf_db_host.value 
+    DB_HOST  = data.aws_ssm_parameter.cclf_db_host.value
   }
 }
 

--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -6,14 +6,10 @@ locals {
     prod = "east-prod"
   }
   db_sg_name = {
-    ab2d = "ab2d-${local.bcda_db_envs[var.env]}-database-sg"
     bcda = "bcda-${var.env}-rds"
-    dpc  = "dpc-${var.env}-db"
   }
   memory_size = {
-    ab2d = 1024
     bcda = 1024
-    dpc  = null
   }
 }
 
@@ -41,8 +37,8 @@ module "cclf_import_function" {
   name        = local.full_name
   description = "Ingests the most recent CCLF from BFD"
 
-  handler = var.app == "bcda" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap" # TODO: check handlers
-  runtime = var.app == "bcda" ? "java11" : "provided.al2" # TODO: check runtime
+  handler = "cclf-import"
+  runtime = "provided.al2"
 
   memory_size = local.memory_size[var.app]
 
@@ -53,7 +49,7 @@ module "cclf_import_function" {
   environment_variables = {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-cclf-import"
-    DB_HOST  = data.aws_ssm_parameter.opt_out_db_host.value #TODO: What is this
+    DB_HOST  = data.aws_ssm_parameter.cclf_db_host.value #TODO: What is this
   }
 }
 

--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -24,10 +24,6 @@ data "aws_iam_policy_document" "assume_bucket_role" {
   }
 }
 
-data "aws_ssm_parameter" "cclf_db_host" {
-  name = "/${var.app}/${var.env}/cclf/db-host"
-}
-
 module "cclf_import_function" {
   source = "../../modules/function"
 
@@ -49,7 +45,6 @@ module "cclf_import_function" {
   environment_variables = {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-cclf-import"
-    DB_HOST  = data.aws_ssm_parameter.cclf_db_host.value
   }
 }
 

--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -49,7 +49,7 @@ module "cclf_import_function" {
   environment_variables = {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-cclf-import"
-    DB_HOST  = data.aws_ssm_parameter.cclf_db_host.value #TODO: What is this
+    DB_HOST  = data.aws_ssm_parameter.cclf_db_host.value 
   }
 }
 

--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -1,0 +1,90 @@
+locals {
+  full_name = "${var.app}-${var.env}-cclf-import"
+  bcda_db_envs = {
+    dev  = "dev"
+    test = "east-impl"
+    prod = "east-prod"
+  }
+  db_sg_name = {
+    ab2d = "ab2d-${local.bcda_db_envs[var.env]}-database-sg"
+    bcda = "bcda-${var.env}-rds"
+    dpc  = "dpc-${var.env}-db"
+  }
+  memory_size = {
+    ab2d = 1024
+    bcda = 1024
+    dpc  = null
+  }
+}
+
+data "aws_ssm_parameter" "bfd_bucket_role_arn" {
+  name = "/cclf-import/${var.app}/${var.env}/bfd-bucket-role-arn"
+}
+
+data "aws_iam_policy_document" "assume_bucket_role" {
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = [data.aws_ssm_parameter.bfd_bucket_role_arn.value]
+  }
+}
+
+data "aws_ssm_parameter" "cclf_db_host" {
+  name = "/${var.app}/${var.env}/cclf/db-host"
+}
+
+module "cclf_import_function" {
+  source = "../../modules/function"
+
+  app = var.app
+  env = var.env
+
+  name        = local.full_name
+  description = "Ingests the most recent CCLF from BFD"
+
+  handler = var.app == "bcda" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap" # TODO: check handlers
+  runtime = var.app == "bcda" ? "java11" : "provided.al2" # TODO: check runtime
+
+  memory_size = local.memory_size[var.app]
+
+  function_role_inline_policies = {
+    assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json
+  }
+
+  environment_variables = {
+    ENV      = var.env
+    APP_NAME = "${var.app}-${var.env}-cclf-import"
+    DB_HOST  = data.aws_ssm_parameter.opt_out_db_host.value #TODO: What is this
+  }
+}
+
+# Set up queue for receiving messages when a file is added to the bucket
+
+data "aws_ssm_parameter" "bfd_sns_topic_arn" {
+  name = "/cclf-import/${var.app}/${var.env}/bfd-sns-topic-arn"
+}
+
+module "cclf_import_queue" {
+  source = "../../modules/queue"
+
+  name = local.full_name
+
+  function_name = module.cclf_import_function.name
+  sns_topic_arn = data.aws_ssm_parameter.bfd_sns_topic_arn.value
+}
+
+# Add a rule to the database security group to allow access from the function
+
+data "aws_security_group" "db" {
+  name = local.db_sg_name[var.app]
+}
+
+resource "aws_security_group_rule" "function_access" {
+  type        = "ingress"
+  from_port   = 5432
+  to_port     = 5432
+  protocol    = "tcp"
+  description = "cclf-import function access"
+
+  security_group_id        = data.aws_security_group.db.id
+  source_security_group_id = module.cclf_import_function.security_group_id
+}

--- a/terraform/services/cclf-import/outputs.tf
+++ b/terraform/services/cclf-import/outputs.tf
@@ -1,4 +1,3 @@
-# TODO: Are these needed? Any extras?
 output "function_role_arn" {
   value = module.cclf_import_function.role_arn
 }

--- a/terraform/services/cclf-import/outputs.tf
+++ b/terraform/services/cclf-import/outputs.tf
@@ -1,0 +1,12 @@
+# TODO: Are these needed? Any extras?
+output "function_role_arn" {
+  value = module.cclf_import_function.role_arn
+}
+
+output "sqs_queue_arn" {
+  value = module.cclf_import_queue.arn
+}
+
+output "zip_bucket" {
+  value = module.cclf_import_function.zip_bucket
+}

--- a/terraform/services/cclf-import/terraform.tf
+++ b/terraform/services/cclf-import/terraform.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      application = var.app
+      business    = "oeda"
+      code        = "https://github.com/CMSgov/ab2d-bcda-dpc-platform/tree/main/terraform/services/cclf-import"
+      component   = "cclf-import"
+      environment = var.env
+      terraform   = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "cclf-import/terraform.tfstate"
+  }
+}

--- a/terraform/services/cclf-import/variables.tf
+++ b/terraform/services/cclf-import/variables.tf
@@ -1,0 +1,17 @@
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
+  type        = string
+  validation {
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, or prod."
+  }
+}

--- a/terraform/services/cclf-import/variables.tf
+++ b/terraform/services/cclf-import/variables.tf
@@ -1,9 +1,9 @@
 variable "app" {
-  description = "The application name (ab2d, bcda, dpc)"
+  description = "The application name (bcda)"
   type        = string
   validation {
-    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
-    error_message = "Valid value for app is ab2d, bcda, or dpc."
+    condition     = contains(["bcda"], var.app)
+    error_message = "Valid value for app is bcda."
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8105

## 🛠 Changes

Adding Terraform infrastructure for cclf-import lambda functions.
 
## ℹ️ Context for reviewers

Used existing opt-out import service as a template.
cclf-import lambda will only be used by BCDA.
This is partly a check of work. 

## ✅ Acceptance Validation

Not verified. If things look good from a code sense, testing can happen. Not sure on testing and how to perform it.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
