### PR TITLE
BCDA-7898: Add bcda check for opt-out-import

### DIFF
--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -38,7 +38,7 @@ module "opt_out_import_function" {
   app = var.app
   env = var.env
 
-  name        = var.app == "bcda" ? "opt-out-import" : local.full_name
+  name        = local.full_name
   description = "Ingests the most recent beneficiary opt-out list from BFD"
 
   handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -41,7 +41,7 @@ module "opt_out_import_function" {
   name        = local.full_name
   description = "Ingests the most recent beneficiary opt-out list from BFD"
 
-  handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"
+  handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : var.app == "bcda" ? "opt-out-import" : "bootstrap"
   runtime = var.app == "ab2d" ? "java11" : "provided.al2"
 
   memory_size = local.memory_size[var.app]

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -15,6 +15,11 @@ locals {
     bcda = null
     dpc  = null
   }
+  handler_name = {
+    ab2d = "gov.cms.ab2d.optout.OptOutHandler"
+    bcda = "opt-out-import"
+    dpc  = "bootstrap"
+  }
 }
 
 data "aws_ssm_parameter" "bfd_bucket_role_arn" {
@@ -41,7 +46,7 @@ module "opt_out_import_function" {
   name        = local.full_name
   description = "Ingests the most recent beneficiary opt-out list from BFD"
 
-  handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : var.app == "bcda" ? "opt-out-import" : "bootstrap"
+  handler = local.handler_name[var.app]
   runtime = var.app == "ab2d" ? "java11" : "provided.al2"
 
   memory_size = local.memory_size[var.app]

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -38,7 +38,7 @@ module "opt_out_import_function" {
   app = var.app
   env = var.env
 
-  name        = local.full_name
+  name        = var.app == "bcda" ? "opt-out-import" : local.full_name
   description = "Ingests the most recent beneficiary opt-out list from BFD"
 
   handler = var.app == "ab2d" ? "gov.cms.ab2d.optout.OptOutHandler" : "bootstrap"


### PR DESCRIPTION
Adds a check for bcda in order to correctly name the opt-out-import function handler.

## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-7898

## 🛠 Changes

Added a check for the app variable in order to change the handler name within the opt-out-import function.

## ℹ️ Context for reviewers

Making it so that BCDA is properly supported for opt-out import.

## ✅ Acceptance Validation

See plans in checks.

## 🔒 Security Implications

None.
