### PR TITLE
PLT-474 Set default queue visibility timeout to 900

### DIFF
--- a/terraform/modules/queue/main.tf
+++ b/terraform/modules/queue/main.tf
@@ -14,6 +14,8 @@ resource "aws_sqs_queue" "this" {
   name              = var.name
   kms_master_key_id = module.queue_key.id
 
+  visibility_timeout_seconds = var.visibility_timeout_seconds
+
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.dead_letter.arn
     maxReceiveCount     = 4

--- a/terraform/modules/queue/outputs.tf
+++ b/terraform/modules/queue/outputs.tf
@@ -1,4 +1,4 @@
 output "arn" {
   description = "ARN for the queue"
-  value = aws_sqs_queue.this.arn
+  value       = aws_sqs_queue.this.arn
 }

--- a/terraform/modules/queue/variables.tf
+++ b/terraform/modules/queue/variables.tf
@@ -13,5 +13,12 @@ variable "sns_topic_arn" {
   type        = string
   # Setting default to "None" allows us to set the AWS Parameter Store value
   # to "None" to disable creation of SNS Topic Subscription
-  default     = "None"
+  default = "None"
+}
+
+variable "visibility_timeout_seconds" {
+  description = "Queue visibility timeout in seconds"
+  type        = number
+  # Default is 900 to match default timeout in modules/function/variables.tf
+  default = 900
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-474

## 🛠 Changes

Queue visibility timeout set to default of 900.

## ℹ️ Context

With the function timeout set at 900 seconds but the queue visibility timeout at it's standard default of 30 we were [seeing this error](https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/9404631602/job/25903957138#step:6:933) on apply: 

```
InvalidParameterValueException: Queue visibility timeout: 30 seconds is less than Function timeout: 900 seconds
```

This change updates the default for the queue module to match the function module. See some background at https://github.com/aws/serverless-application-model/issues/1424 where the reasons for why these must match is explained.

## 🧪 Validation

See plans in checks. I've also successfully applied in dev and test environments.