### PR TITLE
BCDA-8208: Rename BCDA lambda handlers to bootstrap

### DIFF
--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -33,7 +33,7 @@ module "cclf_import_function" {
   name        = local.full_name
   description = "Ingests the most recent CCLF from BFD"
 
-  handler = "cclf-import"
+  handler = "bootstrap"
   runtime = "provided.al2"
 
   memory_size = local.memory_size[var.app]

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -17,7 +17,7 @@ locals {
   }
   handler_name = {
     ab2d = "gov.cms.ab2d.optout.OptOutHandler"
-    bcda = "opt-out-import"
+    bcda = "bootstrap"
     dpc  = "bootstrap"
   }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8208

## 🛠 Changes

- Rename handlers to bootstrap

## ℹ️ Context

Was looking at the lambda logs and saw some errors with trying to find the entrypoint. After reading the AWS documentation, I realized that it expects the zip file to have exactly one binary, which is specifically named bootstrap 😅

This was an oversight on my part — I thought if the handler was specified as cclf-import / opt-out-import here, it would look for that binary filename instead.

## 🧪 Validation

Changed manually in AWS Console and confirmed successful lambda initialization.
