### PR TITLE
PLT-355 Add policy statements for key user roles

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -2,8 +2,7 @@ module "bucket_key" {
   source      = "../key"
   name        = "${var.name}-bucket"
   description = "For ${var.name} S3 bucket and its access logs"
-
-  additional_access_roles = var.cross_account_read_roles
+  user_roles  = var.cross_account_read_roles
 }
 
 resource "aws_s3_bucket" "this" {

--- a/terraform/modules/key/variables.tf
+++ b/terraform/modules/key/variables.tf
@@ -21,8 +21,8 @@ variable "buckets" {
   default     = []
 }
 
-variable "additional_access_roles" {
-  description = "ARNs for additional roles that need access to this key"
+variable "user_roles" {
+  description = "ARNs for roles (generally in other accounts) that will use this key"
   type        = list
   default     = []
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-355

## 🛠 Changes

Policy statements added to KMS key module for roles to use keys without having full admin access.

## ℹ️ Context

In looking into using customer-managed KMS keys while creating our access-log bucket, I realized we had set the policy on access/use roles too open.

@SJWalter11 This will tighten permissions around KMS keys created for opt-out functions in test environments.

## 🧪 Validation

See checks.