### PR TITLE
PLT-476 Notify platform channel on failed terraform apply in platform repo

### DIFF
--- a/.github/workflows/cclf-import-apply.yml
+++ b/.github/workflows/cclf-import-apply.yml
@@ -41,7 +41,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'

--- a/.github/workflows/cclf-import-apply.yml
+++ b/.github/workflows/cclf-import-apply.yml
@@ -41,12 +41,12 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-      - name: notify slack
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ'
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
           payload: |
             {
               "text": "GitHub Action failed",
@@ -55,7 +55,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Terraform apply failure*"
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
                   }
                 },
                 {
@@ -68,7 +68,7 @@ jobs:
                         "text": "Link to failed job"
                       },
                       "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    },
+                    }
                   ]
                 }
               ]
@@ -76,3 +76,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/cclf-import-apply.yml
+++ b/.github/workflows/cclf-import-apply.yml
@@ -46,34 +46,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/cclf-import-apply.yml
+++ b/.github/workflows/cclf-import-apply.yml
@@ -41,13 +41,13 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B'
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/cclf-import-apply.yml
+++ b/.github/workflows/cclf-import-apply.yml
@@ -41,4 +41,47 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-
+      - name: notify slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        # https://api.slack.com/apps/<your-app-id>/incoming-webhooks
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel #alerts-test
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Production deployment check failed* :fire_engine:\n High error rate detected after deployment! Rolling back..."
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":github: Failed action"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":grafana: Grafana dashboard"
+                      },
+                      "url": "https://www.google.com/"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/cclf-import-apply.yml
+++ b/.github/workflows/cclf-import-apply.yml
@@ -44,10 +44,9 @@ jobs:
       - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.24.0
-        # https://api.slack.com/apps/<your-app-id>/incoming-webhooks
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel #alerts-test
+          channel-id: 'T07AYTHK0QJ'
           payload: |
             {
               "text": "GitHub Action failed",
@@ -56,7 +55,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Production deployment check failed* :fire_engine:\n High error rate detected after deployment! Rolling back..."
+                    "text": "*Terraform apply failure*"
                   }
                 },
                 {
@@ -66,18 +65,10 @@ jobs:
                       "type": "button",
                       "text": {
                         "type": "plain_text",
-                        "text": ":github: Failed action"
+                        "text": "Link to failed job"
                       },
                       "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     },
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": ":grafana: Grafana dashboard"
-                      },
-                      "url": "https://www.google.com/"
-                    }
                   ]
                 }
               ]

--- a/.github/workflows/cclf-import-apply.yml
+++ b/.github/workflows/cclf-import-apply.yml
@@ -41,13 +41,11 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-      - name: notify slack
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-oidc-provider-apply.yml
+++ b/.github/workflows/github-actions-oidc-provider-apply.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B' 

--- a/.github/workflows/github-actions-oidc-provider-apply.yml
+++ b/.github/workflows/github-actions-oidc-provider-apply.yml
@@ -43,34 +43,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-oidc-provider-apply.yml
+++ b/.github/workflows/github-actions-oidc-provider-apply.yml
@@ -38,13 +38,11 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack 
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B' 
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-oidc-provider-apply.yml
+++ b/.github/workflows/github-actions-oidc-provider-apply.yml
@@ -38,3 +38,39 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Link to failed job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/github-actions-oidc-provider-apply.yml
+++ b/.github/workflows/github-actions-oidc-provider-apply.yml
@@ -38,13 +38,13 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack 
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B' 
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-role-apply.yml
+++ b/.github/workflows/github-actions-role-apply.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'

--- a/.github/workflows/github-actions-role-apply.yml
+++ b/.github/workflows/github-actions-role-apply.yml
@@ -45,34 +45,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-role-apply.yml
+++ b/.github/workflows/github-actions-role-apply.yml
@@ -40,13 +40,13 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B'
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-role-apply.yml
+++ b/.github/workflows/github-actions-role-apply.yml
@@ -40,13 +40,11 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-role-apply.yml
+++ b/.github/workflows/github-actions-role-apply.yml
@@ -40,3 +40,39 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Link to failed job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/github-actions-runner-apply.yml
+++ b/.github/workflows/github-actions-runner-apply.yml
@@ -43,34 +43,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-runner-apply.yml
+++ b/.github/workflows/github-actions-runner-apply.yml
@@ -38,7 +38,7 @@ jobs:
             TF_VAR_key_base64=/github-runner/app-key-base64
             TF_VAR_webhook_secret=/github-runner/webhook-secret
       - run: terraform apply -auto-approve
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'

--- a/.github/workflows/github-actions-runner-apply.yml
+++ b/.github/workflows/github-actions-runner-apply.yml
@@ -38,13 +38,13 @@ jobs:
             TF_VAR_key_base64=/github-runner/app-key-base64
             TF_VAR_webhook_secret=/github-runner/webhook-secret
       - run: terraform apply -auto-approve
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B'
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/github-actions-runner-apply.yml
+++ b/.github/workflows/github-actions-runner-apply.yml
@@ -38,3 +38,39 @@ jobs:
             TF_VAR_key_base64=/github-runner/app-key-base64
             TF_VAR_webhook_secret=/github-runner/webhook-secret
       - run: terraform apply -auto-approve
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Link to failed job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/github-actions-runner-apply.yml
+++ b/.github/workflows/github-actions-runner-apply.yml
@@ -38,13 +38,11 @@ jobs:
             TF_VAR_key_base64=/github-runner/app-key-base64
             TF_VAR_webhook_secret=/github-runner/webhook-secret
       - run: terraform apply -auto-approve
-      - name: notify slack
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/opt-out-export-apply.yml
+++ b/.github/workflows/opt-out-export-apply.yml
@@ -40,13 +40,11 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-      - name: notify slack
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/opt-out-export-apply.yml
+++ b/.github/workflows/opt-out-export-apply.yml
@@ -45,34 +45,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/opt-out-export-apply.yml
+++ b/.github/workflows/opt-out-export-apply.yml
@@ -40,3 +40,39 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Link to failed job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/opt-out-export-apply.yml
+++ b/.github/workflows/opt-out-export-apply.yml
@@ -40,7 +40,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'

--- a/.github/workflows/opt-out-export-apply.yml
+++ b/.github/workflows/opt-out-export-apply.yml
@@ -40,13 +40,13 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B'
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -41,7 +41,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -46,34 +46,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -41,13 +41,13 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B'
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -41,3 +41,39 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Link to failed job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/opt-out-import-apply.yml
+++ b/.github/workflows/opt-out-import-apply.yml
@@ -41,8 +41,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -reconfigure -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env.s3.tfbackend
       - run: terraform apply -auto-approve
-      - name: notify slack
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:

--- a/.github/workflows/snyk-integration-apply.yml
+++ b/.github/workflows/snyk-integration-apply.yml
@@ -43,34 +43,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/snyk-integration-apply.yml
+++ b/.github/workflows/snyk-integration-apply.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'

--- a/.github/workflows/snyk-integration-apply.yml
+++ b/.github/workflows/snyk-integration-apply.yml
@@ -38,3 +38,39 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Link to failed job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/snyk-integration-apply.yml
+++ b/.github/workflows/snyk-integration-apply.yml
@@ -38,13 +38,13 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B'
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/snyk-integration-apply.yml
+++ b/.github/workflows/snyk-integration-apply.yml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/snyk-integration-apply.yml
+++ b/.github/workflows/snyk-integration-apply.yml
@@ -38,8 +38,6 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:

--- a/.github/workflows/tfstate-apply.yml
+++ b/.github/workflows/tfstate-apply.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/tfstate-apply.yml
+++ b/.github/workflows/tfstate-apply.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'

--- a/.github/workflows/tfstate-apply.yml
+++ b/.github/workflows/tfstate-apply.yml
@@ -45,34 +45,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/tfstate-apply.yml
+++ b/.github/workflows/tfstate-apply.yml
@@ -40,13 +40,13 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B'
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/tfstate-apply.yml
+++ b/.github/workflows/tfstate-apply.yml
@@ -40,8 +40,6 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:

--- a/.github/workflows/tfstate-apply.yml
+++ b/.github/workflows/tfstate-apply.yml
@@ -40,3 +40,39 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Link to failed job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/zscaler-security-groups-apply.yml
+++ b/.github/workflows/zscaler-security-groups-apply.yml
@@ -43,34 +43,8 @@ jobs:
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
-          payload: |
-            {
-              "text": "GitHub Action failed",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "Link to failed job"
-                      },
-                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                    }
-                  ]
-                }
-              ]
-            }
+          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
+          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/zscaler-security-groups-apply.yml
+++ b/.github/workflows/zscaler-security-groups-apply.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-        uses: slackapi/slack-github-action@v1.26.0
+      - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'

--- a/.github/workflows/zscaler-security-groups-apply.yml
+++ b/.github/workflows/zscaler-security-groups-apply.yml
@@ -38,3 +38,39 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
+      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'T07AYTHK0QJ' # slack channel to report terraform apply fail
+          payload: |
+            {
+              "text": "GitHub Action failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Terraform apply failed*\nRun ID:${{ github.run_id }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Link to failed job"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+

--- a/.github/workflows/zscaler-security-groups-apply.yml
+++ b/.github/workflows/zscaler-security-groups-apply.yml
@@ -38,13 +38,13 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack # notify any terraform failiure via slack message in channel #ab2d-bcda-dpc-platform
+      - name: notify slack
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B' # slack channel to report terraform apply fail
-          slack-message: "Terraform apply failure\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}" # message that will be sent to the slack channel with the url
+          channel-id: 'C04UG13JF9B'
+          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/zscaler-security-groups-apply.yml
+++ b/.github/workflows/zscaler-security-groups-apply.yml
@@ -42,7 +42,7 @@ jobs:
         if: ${{ failure() }}
         with:
           channel-id: 'C04UG13JF9B'
-          slack-message: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 

--- a/.github/workflows/zscaler-security-groups-apply.yml
+++ b/.github/workflows/zscaler-security-groups-apply.yml
@@ -38,8 +38,6 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - name: notify slack
-        id: slack
         uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-476

## 🛠 Changes

Added slack notification to all terraform apply failures in the workflow in ab2d-bcda-dpc-platform.

## ℹ️ Context

Notify the platform team in Slack when terraform apply fails to run.

## 🧪 Validation

Use a test github repo and slack channel and check if the notification is sent when the run fails.