### PR TITLE
PLT-338 Update Github Actions Runners to support node20

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -22,10 +22,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-mgmt-github-actions
           aws-region: ${{ vars.AWS_REGION }}
@@ -52,7 +52,7 @@ jobs:
           echo "PKR_VAR_subnet_id=$SUBNET_ID" >> "$GITHUB_ENV"
 
       - name: Setup `packer`
-        uses: hashicorp/setup-packer@v2.0.1
+        uses: hashicorp/setup-packer@v3.1.0
         id: setup
         with:
           version: "latest"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-338

## 🛠 Changes

Updated runners to the latest version to support node20.

## ℹ️ Context

Current Github Action Runner is failing due to node16 being depreciated and the runner version being outdated. Changes were made to have the runner up to date to be compatible with node20.

## 🧪 Validation

Request the changes to be reviewed and tested by the platform member.
