### PR TITLE
PLT-460 Add sg-ip-rules script

### DIFF
--- a/scripts/sg-ip-rules
+++ b/scripts/sg-ip-rules
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+if { [ -z "$1" ]; }; then
+  echo 2>&1 "Usage: ${BASH_SOURCE:-${(%):-%x}} <description> <CIDRs>..."
+  echo 2>&1 "  Where <CIDRs> are IP ranges to be added as ingress rules"
+  echo 2>&1 "  and <description> is applied to each rule."
+  exit 1
+fi
+
+set -x
+
+#apps="ab2d"
+apps="bcda dpc"
+#envs="mgmt"
+envs="dev test prod sbx mgmt"
+
+description="$1"
+shift
+
+ip_ranges="["
+for cidr in "$@"; do
+  ip_ranges+="{CidrIp=$cidr,Description=\"$description\"},"
+done
+ip_ranges+="]"
+
+for app in $apps; do
+  for env in $envs; do
+    sgid=$(aws ec2 describe-security-groups --filters Name=group-name,Values=$app-$env-allow-zscaler-public --query "SecurityGroups[0].GroupId" --output text)
+    aws ec2 authorize-security-group-ingress --group-id $sgid --ip-permissions IpProtocol=-1,IpRanges="$ip_ranges"
+
+    # Comment above and uncomment below to update descriptions instead of adding rules
+    #aws ec2 update-security-group-rule-descriptions-ingress --group-id $sgid --ip-permissions IpProtocol=-1,IpRanges="$ip_ranges"
+  done
+done


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-460

## 🛠 Changes

Added sg-ip-rules script.

## ℹ️ Context

I've added this sg-ip-rules script as an example and something quick modifications could be made to in order to set security group rules quickly from the command line.

## 🧪 Validation

Used in filling in security group rules for zscaler-private and zscaler-public groups for PLT-460.