### PR TITLE
PLT-338 Update Github Actions Runners to support node20

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -22,10 +22,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-mgmt-github-actions
           aws-region: ${{ vars.AWS_REGION }}
@@ -52,7 +52,7 @@ jobs:
           echo "PKR_VAR_subnet_id=$SUBNET_ID" >> "$GITHUB_ENV"
 
       - name: Setup `packer`
-        uses: hashicorp/setup-packer@v3.1.0
+        uses: hashicorp/setup-packer@v2.0.1
         id: setup
         with:
           version: "latest"

--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           params: |
             PKR_VAR_ami_account=/github-runner/gold-image-account
-            PKR_VAR_ami_filter=/github-runner/gold-image-filter
             PKR_VAR_s3_tarball=/github-runner/s3-tarball
 
       - name: Retrieve default VPC ID and subnet

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -28,7 +28,6 @@ build {
   }
 
   provisioner "file" {
-    remote_folder = "/home/ec2-user/"
     content = templatefile("./install-runner.sh", {
       S3_LOCATION_RUNNER_DISTRIBUTION = var.s3_tarball
     })
@@ -44,7 +43,6 @@ build {
   }
 
   provisioner "file" {
-    remote_folder = "/home/ec2-user/"
     content = templatefile("./start-runner.sh", { metadata_tags = "enabled" })
     destination = "/home/ec2-user/start-runner.sh"
   }

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -14,6 +14,7 @@ build {
   ]
 
   provisioner "shell" {
+    remote_folder = "/home/ec2-user/"
     environment_vars = []
     inline = concat([
       "sudo yum -y update --security",
@@ -26,30 +27,29 @@ build {
     ], var.custom_shell_commands)
   }
 
-
   provisioner "file" {
     content = templatefile("./install-runner.sh", {
       S3_LOCATION_RUNNER_DISTRIBUTION = var.s3_tarball
     })
-    destination = "/tmp/install-runner.sh"
+    destination = "/home/ec2-user/install-runner.sh"
   }
 
   provisioner "shell" {
     inline = [
-      "chmod +x /tmp/install-runner.sh",
-      "/tmp/install-runner.sh"
+      "chmod +x /home/ec2-user/install-runner.sh",
+      "/home/ec2-user/install-runner.sh"
     ]
   }
 
   provisioner "file" {
     content = templatefile("./start-runner.sh", { metadata_tags = "enabled" })
-    destination = "/tmp/start-runner.sh"
+    destination = "/home/ec2-user/start-runner.sh"
   }
 
   provisioner "shell" {
     inline = [
-      "sudo mv /tmp/start-runner.sh /var/lib/cloud/scripts/per-boot/start-runner.sh",
-      "sudo chmod +x /var/lib/cloud/scripts/per-boot/start-runner.sh",
+      "sudo mv /home/ec2-user/start-runner.sh /var/lib/cloud/scripts/per-boot/start-runner.sh",
+      "chmod +x /var/lib/cloud/scripts/per-boot/start-runner.sh",
     ]
   }
 

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -12,9 +12,9 @@ build {
   sources = [
     "source.amazon-ebs.github-actions-runner"
   ]
-    remote_folder = "/home/ec2-user/"
 
   provisioner "shell" {
+    remote_folder = "/home/ec2-user/"
     environment_vars = []
     inline = concat([
       "sudo yum -y update --security",
@@ -28,6 +28,7 @@ build {
   }
 
   provisioner "file" {
+    remote_folder = "/home/ec2-user/"
     content = templatefile("./install-runner.sh", {
       S3_LOCATION_RUNNER_DISTRIBUTION = var.s3_tarball
     })
@@ -35,6 +36,7 @@ build {
   }
 
   provisioner "shell" {
+    remote_folder = "/home/ec2-user/"
     inline = [
       "chmod +x /home/ec2-user/install-runner.sh",
       "/home/ec2-user/install-runner.sh"
@@ -42,14 +44,16 @@ build {
   }
 
   provisioner "file" {
+    remote_folder = "/home/ec2-user/"
     content = templatefile("./start-runner.sh", { metadata_tags = "enabled" })
     destination = "/home/ec2-user/start-runner.sh"
   }
 
   provisioner "shell" {
+    remote_folder = "/home/ec2-user/"
     inline = [
       "sudo mv /home/ec2-user/start-runner.sh /var/lib/cloud/scripts/per-boot/start-runner.sh",
-      "chmod +x /var/lib/cloud/scripts/per-boot/start-runner.sh",
+      "sudo chmod +x /var/lib/cloud/scripts/per-boot/start-runner.sh",
     ]
   }
 
@@ -58,3 +62,4 @@ build {
     strip_path = true
   }
 }
+

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -12,9 +12,9 @@ build {
   sources = [
     "source.amazon-ebs.github-actions-runner"
   ]
+    remote_folder = "/home/ec2-user/"
 
   provisioner "shell" {
-    remote_folder = "/home/ec2-user/"
     environment_vars = []
     inline = concat([
       "sudo yum -y update --security",

--- a/packer/github-actions-runner/sources.pkr.hcl
+++ b/packer/github-actions-runner/sources.pkr.hcl
@@ -9,7 +9,9 @@ source "amazon-ebs" "github-actions-runner" {
   iam_instance_profile                      = "bcda-mgmt-github-actions"
 
   source_ami_filter {
-     filters = { name = "${var.ami_filter}" }
+     filters = {
+      name = "al2023-legacy-gi-*"
+     }
     owners = ["${var.ami_account}"]
     most_recent = true
   }

--- a/packer/github-actions-runner/sources.pkr.hcl
+++ b/packer/github-actions-runner/sources.pkr.hcl
@@ -9,7 +9,9 @@ source "amazon-ebs" "github-actions-runner" {
   iam_instance_profile                      = "bcda-mgmt-github-actions"
 
   source_ami_filter {
-    filters = { name = "${var.ami_filter}" }
+     filters = {
+      name = "al2023-legacy-gi-2024-07-10T10-40-52Z" 
+    }
     owners = ["${var.ami_account}"]
     most_recent = true
   }

--- a/packer/github-actions-runner/sources.pkr.hcl
+++ b/packer/github-actions-runner/sources.pkr.hcl
@@ -9,9 +9,7 @@ source "amazon-ebs" "github-actions-runner" {
   iam_instance_profile                      = "bcda-mgmt-github-actions"
 
   source_ami_filter {
-     filters = {
-      name = "al2023-legacy-gi-2024-07-10T10-40-52Z" 
-    }
+     filters = { name = "${var.ami_filter}" }
     owners = ["${var.ami_account}"]
     most_recent = true
   }

--- a/packer/github-actions-runner/variables.pkr.hcl
+++ b/packer/github-actions-runner/variables.pkr.hcl
@@ -7,7 +7,7 @@ variable "region" {
 variable "ami_filter" {
   description = "The filter for searching the AMI"
   type        = string
-  default     = null
+  default     = "al2023-legacy-gi-*"
 }
 
 variable "ami_account" {

--- a/packer/github-actions-runner/variables.pkr.hcl
+++ b/packer/github-actions-runner/variables.pkr.hcl
@@ -4,12 +4,6 @@ variable "region" {
   default     = "us-east-1"
 }
 
-variable "ami_filter" {
-  description = "The filter for searching the AMI"
-  type        = string
-  default     = "al2023-legacy-gi-*"
-}
-
 variable "ami_account" {
   description = "The target AMI account"
   type        = string


### PR DESCRIPTION
## 🎫 Ticket

[PLT-338](https://jira.cms.gov/browse/PLT-338)

## 🛠 Changes

- https://github.com/CMSgov/ab2d-bcda-dpc-platform/pull/104 was reverted
- ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION was set to true in the workflow
- packer build was updated to use al2023-legacy-gi-2024-07-10T10-40-52Z as the base image

## ℹ️ Context

The most [recent automated build](https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/7865662073) of the Github Actions Runner AMI failed due to an update in the [hashicorp/setup-packer](https://github.com/hashicorp/setup-packer) action

## 🧪 Validation

See checks for packer build.
