### PR TITLE
PLT-338 Remove actions to allow use of unsecured node version

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -20,8 +20,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## 🎫 Ticket

[PLT-338](https://jira.cms.gov/browse/PLT-338)

## 🛠 Changes

ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION  environment variable was removed

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
removing ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION env var to check whether the AL2023 image does indeed let us run node20.
<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
