### PR TITLE
BCDA-8301: Increase CCLF import memory size to 3072MB

### DIFF
--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -9,7 +9,7 @@ locals {
     bcda = "bcda-${var.env}-rds"
   }
   memory_size = {
-    bcda = 1024
+    bcda = 2048
   }
 }
 

--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -9,7 +9,7 @@ locals {
     bcda = "bcda-${var.env}-rds"
   }
   memory_size = {
-    bcda = 2048
+    bcda = 3072
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8301

## 🛠 Changes

- Ensure CCLF import has enough memory to process files

## ℹ️ Context

This is a short-term resolution for issues we are seeing with our CCLF import lambda being killed for certain large files. These files are _not_ close to meeting the 1024MB size on their own, but they are downloaded four times within the process.

We will prioritize a fix to ensure that these files are only downloaded once during processing.

https://jira.cms.gov/browse/BCDA-8302

## 🧪 Validation

Increased manually and verified that the lambda could process all the files we were having issues with.
![CleanShot 2024-08-07 at 16 52 46@2x](https://github.com/user-attachments/assets/51c5afbf-6c21-4b67-8722-e57cbd5ef77b)
