### PR TITLE
BCDA: Up CCLF lambda memory

### DIFF
--- a/terraform/services/cclf-import/main.tf
+++ b/terraform/services/cclf-import/main.tf
@@ -9,7 +9,7 @@ locals {
     bcda = "bcda-${var.env}-rds"
   }
   memory_size = {
-    bcda = 1024
+    bcda = 2048
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

n/a

## 🛠 Changes

Upped memory from 1024 to 2048 in BCDA CCLF lambda.

## ℹ️ Context

These changes were made because there are some CCLF files that exceed 1GB that are unable to be processed, after recent [improvements to memory usage being deployed.](https://github.com/CMSgov/bcda-app/pull/985) We have have manually changed the memory in the AWS console to 2048 and verified that it was adequate. This will mitigate future incidents where CCLF files fail to be ingested due to their size.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
