### PR TITLE
PLT-585 Add api-waf apply for dpc dev

### DIFF
--- a/.github/workflows/api-waf-dpc-apply.yml
+++ b/.github/workflows/api-waf-dpc-apply.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [dpc]
-        env: [dev, test, sbx, prod]
+        env: [dev]
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform

--- a/.github/workflows/api-waf-dpc-apply.yml
+++ b/.github/workflows/api-waf-dpc-apply.yml
@@ -1,0 +1,35 @@
+name: api-waf plan terraform
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/api-waf-plan.yml
+      - terraform/services/api-waf/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  terraform-apply:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/api-waf
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [dpc]
+        env: [dev, test, sbx, prod]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
+      - run: terraform apply -auto-approve
+        env:
+          TF_VAR_app: ${{ matrix.app }}
+          TF_VAR_env: ${{ matrix.env }}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-585

## 🛠 Changes

Adds the terraform apply for dpc dev environment.

## ℹ️ Context

We'll need to have a tf apply to be able to utilize the terraform automatically.

## 🧪 Validation

See plan output: https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/10583065125/job/29324204318#step:6:21