### PR TITLE
PLT-585 External services IP sets

### DIFF
--- a/.github/workflows/external-services-ip-sets-apply.yml
+++ b/.github/workflows/external-services-ip-sets-apply.yml
@@ -1,0 +1,37 @@
+name: external-services-ip-sets apply terraform
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/external-services-ip-sets-apply.yml
+      - terraform/services/external-services-ip-sets/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  terraform-apply:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/external-services-ip-sets
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [ab2d]
+        env: [mgmt, dev, test, sbx, prod]
+        include:
+          - app: bcda
+            env: mgmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
+      - run: terraform apply -auto-approve

--- a/.github/workflows/external-services-ip-sets-plan.yml
+++ b/.github/workflows/external-services-ip-sets-plan.yml
@@ -1,0 +1,43 @@
+name: external-services-ip-sets plan terraform
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/external-services-ip-sets-plan.yml
+      - terraform/services/external-services-ip-sets/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  check-terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/external-services-ip-sets
+
+  terraform-plan:
+    needs: check-terraform-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/external-services-ip-sets
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [ab2d]
+        env: [mgmt, dev, test, sbx, prod]
+        include:
+          - app: bcda
+            env: mgmt
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
+      - run: terraform plan

--- a/terraform/services/external-services-ip-sets/README.md
+++ b/terraform/services/external-services-ip-sets/README.md
@@ -1,0 +1,12 @@
+# Terraform for WAF IP sets for external services
+
+This terraform code sets up regional and cloudfront WAF IP sets for external services, including Zscaler, New Relic, etc. The IP ranges within these IP sets are not managed by this terraform.
+
+## Instructions
+
+Pass in a backend file when running terraform init. Example:
+
+```bash
+terraform init -reconfigure -backend-config=../../backends/ab2d-dev.s3.tfbackend
+terraform plan
+```

--- a/terraform/services/external-services-ip-sets/main.tf
+++ b/terraform/services/external-services-ip-sets/main.tf
@@ -1,0 +1,32 @@
+# The address used is from the 203.0.113.0/24 range reserved for
+# documentation, which should be unresolvable in any network. It
+# is only used as a placeholder, and should be overwritten by
+# other processes when managing addresses in these IP sets.
+
+resource "aws_wafv2_ip_set" "regional" {
+  name               = "external-services-regional"
+  description        = "IP ranges for Zscaler, New Relic, etc."
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = ["203.0.113.0/32"]
+
+  lifecycle {
+    ignore_changes = [
+      addresses,
+    ]
+  }
+}
+
+resource "aws_wafv2_ip_set" "cloudfront" {
+  name               = "external-services-cloudfront"
+  description        = "IP ranges for Zscaler, New Relic, etc."
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+  addresses          = ["203.0.113.0/32"]
+
+  lifecycle {
+    ignore_changes = [
+      addresses,
+    ]
+  }
+}

--- a/terraform/services/external-services-ip-sets/terraform.tf
+++ b/terraform/services/external-services-ip-sets/terraform.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      business  = "oeda"
+      code      = "https://github.com/CMSgov/ab2d-bcda-dpc-platform/tree/main/terraform/services/external-services-ip-sets"
+      component = "external-services-ip-sets"
+      terraform = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "external-services-ip-sets/terraform.tfstate"
+  }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-585

## 🛠 Changes

Add WAF IP sets for external services, including Zscaler and New Relic.

## ℹ️ Context

In setting up the new WAF for DPC dev, we realized the need for shared IP sets within an account that would contain IPs for external services. This terraform creates those IP sets but leaves management of the addresses/ranges within them up to other processes (manual for now, automated from CIDRs in the private repo in the future).

## 🧪 Validation

See plans in checks.