### PR TITLE
PLT-585 Drop scope from external-services IP set names

### DIFF
--- a/terraform/services/external-services-ip-sets/main.tf
+++ b/terraform/services/external-services-ip-sets/main.tf
@@ -4,7 +4,7 @@
 # other processes when managing addresses in these IP sets.
 
 resource "aws_wafv2_ip_set" "regional" {
-  name               = "external-services-regional"
+  name               = "external-services"
   description        = "IP ranges for Zscaler, New Relic, etc."
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
@@ -18,7 +18,7 @@ resource "aws_wafv2_ip_set" "regional" {
 }
 
 resource "aws_wafv2_ip_set" "cloudfront" {
-  name               = "external-services-cloudfront"
+  name               = "external-services"
   description        = "IP ranges for Zscaler, New Relic, etc."
   scope              = "CLOUDFRONT"
   ip_address_version = "IPV4"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-585

## 🛠 Changes

Dropped scope from the names of external-services IP sets.

## ℹ️ Context

Small addendum to #116 because it turns out IP sets in different scopes (regional vs cloudfront) can have the same name.

## 🧪 Validation

See plans in checks.