### PR TITLE
PLT-585 IP sets for the api-waf service

### DIFF
--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -1,7 +1,9 @@
 name: api-waf plan terraform
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
     paths:
       - .github/workflows/api-waf-plan.yml
       - terraform/services/api-waf/**

--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -1,11 +1,11 @@
-name: api-waf plan terraform
+name: api-waf apply terraform
 
 on:
   push:
     branches:
       - main
     paths:
-      - .github/workflows/api-waf-plan.yml
+      - .github/workflows/api-waf-apply.yml
       - terraform/services/api-waf/**
   workflow_dispatch: # Allow manual trigger
 

--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -63,7 +63,7 @@ resource "aws_wafv2_web_acl" "this" {
   }
 
   dynamic "rule" {
-    for_each = { for k, v in var.ip_sets: k => v }
+    for_each = var.ip_sets
     iterator = ip_set
 
     content {

--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -96,6 +96,10 @@ resource "aws_wafv2_web_acl" "this" {
     name     = "aws-common"
     priority = 12 # Allow for up to 10 IP sets
 
+    override_action {
+      none {}
+    }
+
     statement {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
@@ -114,6 +118,10 @@ resource "aws_wafv2_web_acl" "this" {
     name     = "aws-ip-reputation"
     priority = 13
 
+    override_action {
+      none {}
+    }
+
     statement {
       managed_rule_group_statement {
         name        = "AWSManagedRulesAmazonIpReputationList"
@@ -131,6 +139,10 @@ resource "aws_wafv2_web_acl" "this" {
   rule {
     name     = "aws-bad-inputs"
     priority = 14
+
+    override_action {
+      none {}
+    }
 
     statement {
       managed_rule_group_statement {

--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -23,6 +23,11 @@ EOT
   }
 }
 
+data "aws_wafv2_ip_set" "external_services" {
+  name  = "external-services"
+  scope = var.scope
+}
+
 resource "aws_wafv2_web_acl" "this" {
   name  = var.name
   scope = var.scope

--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -63,6 +63,56 @@ resource "aws_wafv2_web_acl" "this" {
   }
 
   rule {
+    name     = "services-ip-set"
+    priority = 2
+
+    action {
+      block {}
+    }
+
+    statement {
+      not_statement {
+        statement {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.services.arn
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.name}-services-ip-set"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name     = "clients-ip-set"
+    priority = 2
+
+    action {
+      block {}
+    }
+
+    statement {
+      not_statement {
+        statement {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.services.arn
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.name}-services-ip-set"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
     name     = "aws-common"
     priority = 2
 

--- a/terraform/modules/firewall/variables.tf
+++ b/terraform/modules/firewall/variables.tf
@@ -50,3 +50,9 @@ variable "rate_limit" {
   type        = number
   default     = 300
 }
+
+variable "ip_sets" {
+  description = "IP sets to allow"
+  type        = list(string)
+  default     = []
+}

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -16,6 +16,28 @@ data "aws_lb" "api" {
   name = local.load_balancers[var.app]
 }
 
+data "aws_wafv2_ip_set" "external_services" {
+  name  = "external-services"
+  scope = "REGIONAL"
+}
+
+resource "aws_wafv2_ip_set" "api_customers" {
+  name               = "${var.app}-${var.env}-api-customers"
+  description        = "IP ranges for customers of this API"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+
+  # Addresses will be managed outside of terraform. This is
+  # a placeholder address.
+  addresses = ["203.0.113.0/32"]
+
+  lifecycle {
+    ignore_changes = [
+      addresses,
+    ]
+  }
+}
+
 module "aws_waf" {
   source = "../../modules/firewall"
 
@@ -27,4 +49,8 @@ module "aws_waf" {
   content_type = "APPLICATION_JSON"
 
   associated_resource_arn = data.aws_lb.api.arn
+  ip_sets = [
+    data.aws_wafv2_ip_set.external_services.arn,
+    aws_wafv2_ip_set.api_customers.arn,
+  ]
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-585

## 🛠 Changes

Added the ability to set IP sets in the firewall module, and added an IP set for customers in the api-waf service. Also referenced the external-services IP set created in #116 and #117.

## ℹ️ Context

This will associate terraform-managed IP sets with the WAF for each API (starting with DPC dev environment). CIDRs in these IP sets will be managed outside of terraform.

## 🧪 Validation

See plans in checks.