### PR TITLE
PLT-585: Add override to aws-common ruleset for XSS check

### DIFF
--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - .github/workflows/api-waf-apply.yml
       - terraform/services/api-waf/**
+      - terraform/modules/firewall/**
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/.github/workflows/api-waf-plan.yml
+++ b/.github/workflows/api-waf-plan.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/api-waf-plan.yml
       - terraform/services/api-waf/**
+      - terraform/modules/firewall/**
   workflow_dispatch: # Allow manual trigger
 
 jobs:

--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -107,6 +107,14 @@ resource "aws_wafv2_web_acl" "this" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        # Override for XSS block on request body, DPC team sends HTML blocks in requests to certain endpoints
+        rule_action_override {
+          name = "CrossSiteScripting_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-585

## 🛠 Changes

This adds an override to the AWSManagedRulesCommonRuleSet's CrossSiteScripting_BODY check to allow DPC to send HTML in the requests to certain endpoints of their API.

## ℹ️ Context

This should fix the failing smoke tests DPC has in the dev environment. We found that this rule had been blocking requests to certain endpoints.

## 🧪 Validation

Terraform plan should pass and the DPC smoke test in DEV should pass once this is applied.
