### PR TITLE
PLT-585: Override size requirement WAF rule

### DIFF
--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -115,6 +115,14 @@ resource "aws_wafv2_web_acl" "this" {
             count {}
           }
         }
+
+        # Override for size requirements of requests, this is set at 8kb which is too small for some acceptable requests
+        rule_action_override {
+          name = "SizeRestrictions_BODY"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-585

## 🛠 Changes

Adds an override block for the `SizeRestrictions_BODY` AWS provided WAF rule.

## ℹ️ Context

After moving to batch requests to avoid hitting the rate limit WAF rule, we foudn that the requests would be too large for AWS' provided WAF rules.

## 🧪 Validation

DPC smoke tests should pass after this is applied.
