### PR TITLE
PLT-563 Add ab2d-prod-test to actions-role and tfstate

### DIFF
--- a/.github/workflows/github-actions-role-apply.yml
+++ b/.github/workflows/github-actions-role-apply.yml
@@ -26,6 +26,8 @@ jobs:
         include:
           - app: ab2d
             env: mgmt
+          - app: ab2d
+            env: prod-test
           - app: bcda
             env: mgmt
     steps:
@@ -33,7 +35,7 @@ jobs:
       - uses: ./actions/setup-tfenv-terraform
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || matrix.env == 'prod-test' && secrets.AB2D_PROD_ACCOUNT || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: terraform apply -auto-approve

--- a/.github/workflows/github-actions-role-plan.yml
+++ b/.github/workflows/github-actions-role-plan.yml
@@ -32,6 +32,8 @@ jobs:
         include:
           - app: ab2d
             env: mgmt
+          - app: ab2d
+            env: prod-test
           - app: bcda
             env: mgmt
     steps:
@@ -39,7 +41,7 @@ jobs:
       - uses: ./actions/setup-tfenv-terraform
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || matrix.env == 'prod-test' && secrets.AB2D_PROD_ACCOUNT || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: terraform plan

--- a/.github/workflows/tfstate-apply.yml
+++ b/.github/workflows/tfstate-apply.yml
@@ -28,6 +28,8 @@ jobs:
         include:
           - app: ab2d
             env: mgmt
+          - app: ab2d
+            env: prod-test
           - app: bcda
             env: mgmt
     steps:
@@ -35,7 +37,7 @@ jobs:
       - uses: ./actions/setup-tfenv-terraform
       - uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || matrix.env == 'prod-test' && secrets.AB2D_PROD_ACCOUNT || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: terraform apply -auto-approve

--- a/.github/workflows/tfstate-plan.yml
+++ b/.github/workflows/tfstate-plan.yml
@@ -34,6 +34,8 @@ jobs:
         include:
           - app: ab2d
             env: mgmt
+          - app: ab2d
+            env: prod-test
           - app: bcda
             env: mgmt
     steps:
@@ -41,7 +43,7 @@ jobs:
       - uses: ./actions/setup-tfenv-terraform
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || matrix.env == 'prod-test' && secrets.AB2D_PROD_ACCOUNT || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: terraform plan


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-563

## 🛠 Changes

Added plan and apply for the prod-test environment for AB2D to github-actions-role and tfstate terraform services. 

## ℹ️ Context

While introducing the api-rds terraform service to AB2D environments with #123 and #125 we saw the need for an environment to manage AB2D's prod-test infrastructure.

## 🧪 Validation

See plans in checks.