### PR TITLE
PLT-503: Add test and sandbox environments to DPC WAF plan and apply

### DIFF
--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [dpc]
-        env: [dev]
+        env: [dev, test, sbx]
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform

--- a/.github/workflows/api-waf-plan.yml
+++ b/.github/workflows/api-waf-plan.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - .github/workflows/api-waf-plan.yml
-      - .github/workflows/api-waf-apply.yml
       - terraform/services/api-waf/**
       - terraform/modules/firewall/**
   workflow_dispatch: # Allow manual trigger

--- a/.github/workflows/api-waf-plan.yml
+++ b/.github/workflows/api-waf-plan.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/api-waf-plan.yml
+      - .github/workflows/api-waf-apply.yml
       - terraform/services/api-waf/**
       - terraform/modules/firewall/**
   workflow_dispatch: # Allow manual trigger

--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -62,36 +62,40 @@ resource "aws_wafv2_web_acl" "this" {
     }
   }
 
-  rule {
-    name     = "ip-sets"
-    priority = 2
+  dynamic "rule" {
+    for_each = length(var.ip_sets) > 0 ? [1] : []
 
-    action {
-      block {}
-    }
+    content {
+      name     = "ip-sets"
+      priority = 2
 
-    statement {
-      not_statement {
-        statement {
-          or_statement {
-            dynamic "statement" {
-              for_each = var.ip_sets
-              iterator = ip_set
-              content {
-                ip_set_reference_statement {
-                  arn = ip_set.value
+      action {
+        block {}
+      }
+
+      statement {
+        not_statement {
+          statement {
+            or_statement {
+              dynamic "statement" {
+                for_each = var.ip_sets
+                iterator = ip_set
+                content {
+                  ip_set_reference_statement {
+                    arn = ip_set.value
+                  }
                 }
               }
             }
           }
         }
       }
-    }
 
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "${var.name}-ip-sets"
-      sampled_requests_enabled   = false
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${var.name}-ip-sets"
+        sampled_requests_enabled   = false
+      }
     }
   }
 

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -23,7 +23,7 @@ data "aws_wafv2_ip_set" "external_services" {
 }
 
 resource "aws_wafv2_ip_set" "api_customers" {
-  count = var.env == "sbx" ? 0 : 1
+  count              = var.env == "sbx" ? 0 : 1
   name               = "${var.app}-${var.env}-api-customers"
   description        = "IP ranges for customers of this API"
   scope              = "REGIONAL"

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -52,7 +52,7 @@ module "aws_waf" {
 
   associated_resource_arn = data.aws_lb.api.arn
   ip_sets = var.env == "sbx" ? [] : [
-    data.aws_wafv2_ip_set.external_services.arn,
-    aws_wafv2_ip_set.api_customers.arn,
+    one(data.aws_wafv2_ip_set.external_services.arn),
+    one(aws_wafv2_ip_set.api_customers.arn),
   ]
 }

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -52,7 +52,7 @@ module "aws_waf" {
 
   associated_resource_arn = data.aws_lb.api.arn
   ip_sets = var.env == "sbx" ? [] : [
-    one(data.aws_wafv2_ip_set.external_services.arn),
-    one(aws_wafv2_ip_set.api_customers.arn),
+    one(data.aws_wafv2_ip_set.external_services).arn,
+    one(aws_wafv2_ip_set.api_customers).arn,
   ]
 }

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -17,11 +17,13 @@ data "aws_lb" "api" {
 }
 
 data "aws_wafv2_ip_set" "external_services" {
+  count = var.env == "sbx" ? 0 : 1
   name  = "external-services"
   scope = "REGIONAL"
 }
 
 resource "aws_wafv2_ip_set" "api_customers" {
+  count = var.env == "sbx" ? 0 : 1
   name               = "${var.app}-${var.env}-api-customers"
   description        = "IP ranges for customers of this API"
   scope              = "REGIONAL"
@@ -49,7 +51,7 @@ module "aws_waf" {
   content_type = "APPLICATION_JSON"
 
   associated_resource_arn = data.aws_lb.api.arn
-  ip_sets = [
+  ip_sets = var.env == "sbx" ? [] : [
     data.aws_wafv2_ip_set.external_services.arn,
     aws_wafv2_ip_set.api_customers.arn,
   ]


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-503

## 🛠 Changes

Adds test and sbx environments to the DPC WAF configuration

## ℹ️ Context

These are changes made as a part of the overall WAF migration work.

## 🧪 Validation

Once this is applied, we should see the Web ACL configurations show up with the placeholder IP sets. We'll need to manually update them in AWS, and then reapply once we remove the association with the security group on ingress.