### PR TITLE
PLT-504: Add BCDA dev environment to WAF configuration

### DIFF
--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -24,6 +24,9 @@ jobs:
       matrix:
         app: [dpc]
         env: [dev, test, sbx]
+        include:
+          - app: bcda
+            env: dev
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -30,7 +30,7 @@ resource "aws_wafv2_ip_set" "api_customers" {
   ip_address_version = "IPV4"
 
   # Addresses will be managed outside of terraform. This is
-  # a placeholder address.
+  # a placeholder address for all apps/environments.
   addresses = ["203.0.113.0/32"]
 
   lifecycle {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-504

## 🛠 Changes

This adds the BCDA dev environment to the apply workflow of the new WAF configuration.

## ℹ️ Context

We're moving all apps to WAF for IP filtering. This should alleviate some of the issues we have with security groups and maintaining our CIDR whitelists.

## 🧪 Validation

BCDA dev should be able to be reached on the VPN, but no other traffic should be let through. The BCDA team may need to add CIDR ranges to the new IP-set that will be created. We'll also need to remove the association to the dev WAF and security group in place in the bcda-ops repo: https://github.com/CMSgov/bcda-ops/pull/1114
