### PR TITLE
PLT-650: Add BCDA to apply matrix for WAF config

### DIFF
--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -22,11 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [dpc]
+        app: [bcda, dpc]
         env: [dev, test, sbx]
-        include:
-          - app: bcda
-            env: dev
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -31,6 +31,7 @@ resource "aws_wafv2_ip_set" "api_customers" {
 
   # Addresses will be managed outside of terraform. This is
   # a placeholder address for all apps/environments.
+  # See: https://confluence.cms.gov/x/UDs2Q
   addresses = ["203.0.113.0/32"]
 
   lifecycle {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-650

## 🛠 Changes

Adds BCDA to the apply workflow and updates a comment with a link to the decision log

## ℹ️ Context

We're continuing our rollout of the new WAF config to the BCDA test and sandbox environments.

## 🧪 Validation

Smoke tests should succeed in each environment and network traffic should remain the same. To be merged after https://github.com/CMSgov/bcda-ops/pull/1118 is approved and deployed to the environments.