### PR TITLE
PLT-671 Fix github-actions-runner-apply workflow

### DIFF
--- a/.github/workflows/github-actions-runner-apply.yml
+++ b/.github/workflows/github-actions-runner-apply.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           params: |
             TF_VAR_ami_account=/github-runner/ami-account
-            TF_VAR_ami_filter=/github-runner/ami-filter
             TF_VAR_app_id=/github-runner/app-id
             TF_VAR_key_base64=/github-runner/app-key-base64
             TF_VAR_webhook_secret=/github-runner/webhook-secret

--- a/.github/workflows/github-actions-runner-apply.yml
+++ b/.github/workflows/github-actions-runner-apply.yml
@@ -40,8 +40,7 @@ jobs:
       - uses: slackapi/slack-github-action@v1.26.0
         if: ${{ failure() }}
         with:
-          channel-id: 'C04UG13JF9B'
+          channel-id: 'CNVRZ73NF' # cdap
           slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-671

## 🛠 Changes

Dropped unused terraform variable and updated slack channel for alerts.

## ℹ️ Context

We saw an error in the apply with the recent merge to main. See the run at https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/11405915837/job/31738457455. Also, the alert was sent to the cdap-users channel when it should go to cdap.

## 🧪 Validation

See manual run of apply workflow at https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/11408130895/job/31745654912.