### PR TITLE
PLT-724 fixed parameter error for rds.logical_replication

### DIFF
--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -109,7 +109,7 @@ resource "aws_db_parameter_group" "parameter_group" {
   }
   parameter {
     name         = "rds.logical_replication"
-    value        = contains(["ab2d-dev", "ab2d-east-impl"], local.db_name) ? "1" : "0"
+    value        = 0 # contains(["ab2d-dev", "ab2d-east-impl"], local.db_name) ? "1" : "0" # To support blue-green deployment for PostGres16 upgrade
     apply_method = "pending-reboot"
   }
 
@@ -144,7 +144,7 @@ resource "aws_db_parameter_group" "v16_parameter_group" {
   }
   parameter {
     name         = "rds.logical_replication"
-    value        = "1"
+    value        = 0 # contains(["ab2d-dev", "ab2d-east-impl"], local.db_name) ? "1" : "0" # To support blue-green deployment for PostGres16 upgrade
     apply_method = "pending-reboot"
   }
 

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -110,7 +110,7 @@ resource "aws_db_parameter_group" "parameter_group" {
   parameter {
     name         = "rds.logical_replication"
     value        = contains(["ab2d-dev", "ab2d-east-impl"], local.db_name) ? "1" : "0"
-    apply_method = "immediate"
+    apply_method = "pending-reboot"
   }
 
   lifecycle {
@@ -145,7 +145,7 @@ resource "aws_db_parameter_group" "v16_parameter_group" {
   parameter {
     name         = "rds.logical_replication"
     value        = "1"
-    apply_method = "immediate"
+    apply_method = "pending-reboot"
   }
 
   lifecycle {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-724 

## 🛠 Changes

Changing rds.logical_replication from immediate to pending-reboot apply method

## ℹ️ Context

AWS/Hashicorp documentation was unclear that the parameter was static and could not be applied immediately, and verification via plan/github action was misleading as the plan showed no errors, but the apply did error.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Successful plan locally, validated all "immediate" apply method parameters referenced are dynamic by postgres documentation
