### PR TITLE
Override NoUserAgent_HEADER block on WAF config

### DIFF
--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -112,14 +112,6 @@ resource "aws_wafv2_web_acl" "this" {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
 
-        # Override for XSS block on request body, DPC team sends HTML blocks in requests to certain endpoints
-        rule_action_override {
-          name = "CrossSiteScripting_BODY"
-          action_to_use {
-            count {}
-          }
-        }
-
         # Override for size requirements of requests, this is set at 8kb which is too small for some acceptable requests
         rule_action_override {
           name = "SizeRestrictions_BODY"
@@ -128,11 +120,25 @@ resource "aws_wafv2_web_acl" "this" {
           }
         }
 
+        # Override for XSS block on request body, DPC team sends HTML blocks in requests to certain endpoints
+        dynamic "rule_action_override" {
+          for_each = var.app == "dpc" ? ["apply"] : []
+          content {
+            name = "CrossSiteScripting_BODY"
+            action_to_use {
+              count {}
+            }
+          }
+        }
+
         # Override for requests lacking a User-Agent header, as most BCDA requests are automated and lack them
-        rule_action_override {
-          name = "NoUserAgent_HEADER"
-          action_to_use {
-            count {}
+        dynamic "rule_action_override" {
+          for_each = var.app == "bcda" ? ["apply"] : []
+          content {
+            name = "NoUserAgent_HEADER"
+            action_to_use {
+              count {}
+            }
           }
         }
       }

--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -127,6 +127,14 @@ resource "aws_wafv2_web_acl" "this" {
             count {}
           }
         }
+
+        # Override for requests lacking a User-Agent header, as most BCDA requests are automated and lack them
+        rule_action_override {
+          name = "NoUserAgent_HEADER"
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-635

## 🛠 Changes

Adds an override for requests lacking the User-Agent HTTP header

## ℹ️ Context

BCDA receives a majority of their requests from automated systems that lack this header, and do not require it in the previous iteration of the WAF.

## 🧪 Validation

Requests with no user-agent header (eg., scheduled FHIR scan requests) should pass through the WAF.
