### PR TITLE
PLT-728 update state and tf to postgres upgrade

### DIFF
--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -160,17 +160,17 @@ resource "aws_db_parameter_group" "v16_parameter_group" {
   }
   parameter {
     name         = "max_logical_replication_workers"
-    values       = "22"
+    value        = "22"
     apply_method = "pending-reboot"
   }
   parameter {
     name         = "max_worker_processes"
-    values       = "25"
+    value        = "25"
     apply_method = "pending-reboot"
   }
   parameter {
     name         = "max_wal_senders"
-    values       = "20"
+    value        = "20"
     apply_method = "pending-reboot"
   }
 

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -92,21 +92,6 @@ resource "aws_db_parameter_group" "v16_parameter_group" {
     value        = 0
     apply_method = "pending-reboot"
   }
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "22"
-    apply_method = "pending-reboot"
-  }
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-  parameter {
-    name         = "max_wal_senders"
-    value        = "20"
-    apply_method = "pending-reboot"
-  }
 
   lifecycle {
     create_before_destroy = true

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -9,26 +9,6 @@ locals {
     bcda = "${var.app}-${var.env}"
     dpc  = "${var.app}-${var.env}"
   }[var.app]
-  postgres_ver = {
-    ab2d = {
-      dev  = 16
-      test = 16
-      sbx  = 15
-      prod = 15
-    }[var.env]
-    bcda = {
-      dev  = 15
-      test = 15
-      sbx  = 15
-      prod = 15
-    }[var.env]
-    dpc = {
-      dev  = 14
-      test = 14
-      sbx  = 14
-      prod = 14
-    }[var.env]
-  }[var.app]
 }
 
 ## Begin module/main.tf
@@ -83,52 +63,6 @@ resource "aws_db_subnet_group" "subnet_group" {
 
 # Create database parameter group
 
-resource "aws_db_parameter_group" "parameter_group" {
-  name   = "${local.db_name}-rds-parameter-group-v15"
-  family = "postgres15"
-
-  parameter {
-    name         = "backslash_quote"
-    value        = "safe_encoding"
-    apply_method = "immediate"
-  }
-  parameter {
-    name         = "shared_preload_libraries"
-    value        = "pg_stat_statements,pg_cron"
-    apply_method = "pending-reboot"
-  }
-  parameter {
-    name         = "cron.database_name"
-    value        = var.app == "ab2d" && var.env == "test" ? "impl" : var.env
-    apply_method = "pending-reboot"
-  }
-  parameter {
-    name         = "statement_timeout"
-    value        = "1200000"
-    apply_method = "immediate"
-  }
-  parameter {
-    name         = "rds.logical_replication"
-    value        = 0 # contains(["ab2d-dev", "ab2d-east-impl"], local.db_name) ? "1" : "0" # To support blue-green deployment for PostGres16 upgrade
-    apply_method = "pending-reboot"
-  }
-  parameter {
-    name         = "max_logical_replication_workers"
-    value        = "22"
-    apply_method = "pending-reboot"
-  }
-  parameter {
-    name         = "max_worker_processes"
-    value        = "25"
-    apply_method = "pending-reboot"
-  }
-
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_db_parameter_group" "v16_parameter_group" {
   name   = "${local.db_name}-rds-parameter-group-v16"
   family = "postgres16"
@@ -155,7 +89,7 @@ resource "aws_db_parameter_group" "v16_parameter_group" {
   }
   parameter {
     name         = "rds.logical_replication"
-    value        = 0 # contains(["ab2d-dev", "ab2d-east-impl"], local.db_name) ? "1" : "0" # To support blue-green deployment for PostGres16 upgrade
+    value        = 0
     apply_method = "pending-reboot"
   }
   parameter {
@@ -184,7 +118,7 @@ resource "aws_db_parameter_group" "v16_parameter_group" {
 resource "aws_db_instance" "api" {
   allocated_storage   = 500
   engine              = "postgres"
-  engine_version      = local.postgres_ver
+  engine_version      = 16
   instance_class      = "db.m6i.2xlarge"
   identifier          = local.db_name
   storage_encrypted   = true
@@ -196,7 +130,7 @@ resource "aws_db_instance" "api" {
   skip_final_snapshot = true
 
   db_subnet_group_name    = aws_db_subnet_group.subnet_group.name
-  parameter_group_name    = contains(["ab2d-dev", "ab2d-east-impl"], local.db_name) ? aws_db_parameter_group.v16_parameter_group.name : aws_db_parameter_group.parameter_group.name
+  parameter_group_name    = aws_db_parameter_group.v16_parameter_group.name
   backup_retention_period = 7
   iops                    = local.db_name == "ab2d-east-prod" ? "20000" : "5000"
   apply_immediately       = true

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -114,12 +114,12 @@ resource "aws_db_parameter_group" "parameter_group" {
   }
   parameter {
     name         = "max_logical_replication_workers"
-    values       = "22"
+    value        = "22"
     apply_method = "pending-reboot"
   }
   parameter {
     name         = "max_worker_processes"
-    values       = "25"
+    value        = "25"
     apply_method = "pending-reboot"
   }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-728

## 🛠 Changes

Updating TF to match current AWS state per Postgres 16 upgrade work plan

## ℹ️ Context

Due to technical issues with Postgres 16.4 upgrade there were some settings changed via console and this pull is intended to realign terraform with the intended settings.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local TF plan & TF refresh-only updates for state file; also validating via GHA plan