### PR TITLE
PLT-674 fix: policy resource references and bucket naming

### DIFF
--- a/terraform/services/quicksight/iam.tf
+++ b/terraform/services/quicksight/iam.tf
@@ -111,7 +111,7 @@ resource "aws_iam_policy" "full" {
           "kms:GenerateDataKey*",
           "kms:DescribeKey"
         ]
-        Resource = local.dpc_glue_bucket_key_alias
+        Resource = local.dpc_glue_bucket_key_arn
       }
     ]
   })
@@ -159,7 +159,7 @@ resource "aws_iam_policy" "athena_query_source" {
           "kms:GenerateDataKey*",
           "kms:DescribeKey"
         ]
-        Resource = local.dpc_glue_bucket_key_alias
+        Resource = local.dpc_glue_bucket_key_arn
       }
     ]
   })
@@ -201,7 +201,7 @@ resource "aws_iam_policy" "athena_query_results" {
           "kms:GenerateDataKey*",
           "kms:DescribeKey"
         ]
-        Resource = local.dpc_athena_bucket_key_alias
+        Resource = local.dpc_athena_bucket_key_arn
       }
     ]
   })
@@ -322,7 +322,7 @@ resource "aws_iam_policy" "iam-policy-firehose" {
             "kms:DescribeKey",
           ]
           Effect   = "Allow"
-          Resource = local.dpc_glue_bucket_key_alias
+          Resource = local.dpc_glue_bucket_key_arn
           Sid      = "UseKMSKey"
         },
         {
@@ -571,7 +571,7 @@ resource "aws_iam_policy" "iam-policy-glue-crawler" {
           "kms:Decrypt"
         ]
         Effect   = "Allow"
-        Resource = local.dpc_glue_bucket_key_alias
+        Resource = local.dpc_glue_bucket_key_arn
         Sid      = "CMK"
       }
     ]

--- a/terraform/services/quicksight/main.tf
+++ b/terraform/services/quicksight/main.tf
@@ -17,10 +17,11 @@ locals {
   api_profile  = "${local.stack_prefix}-api"
 
   athena_profile = "${var.app}_${local.this_env}_insights_${local.account_id}"
+  athena_prefix  = "${var.app}-${local.this_env}-insights"
 
   dpc_glue_s3_name    = "${local.stack_prefix}-${local.account_id}"
   dpc_logging_s3_name = "${local.stack_prefix}-logs-${local.account_id}"
-  dpc_athena_s3_name  = local.athena_profile
+  dpc_athena_s3_name  = local.athena_prefix
 
   dpc_glue_bucket_arn         = module.dpc_insights_data.arn
   dpc_glue_bucket_key_alias   = module.dpc_insights_data.key_alias


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-674

## 🛠 Changes

APPLY at merge of original PLT-674 failed due to policy resource reference mistakes (key alias vs ARN) and problematic naming of an S3 bucket.
These changes attempt to resolve.

## ℹ️ Context

see above

## 🧪 Validation

plan succeeds
