### PR TITLE
PLT-634: API WAF - Add BCDA PROD to environment matrix

### DIFF
--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - .github/workflows/api-waf-*
+      - .github/workflows/api-waf-apply.yml
       - terraform/services/api-waf/**
       - terraform/modules/firewall/**
   workflow_dispatch: # Allow manual trigger

--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -27,6 +27,8 @@ jobs:
         include:
           - app: dpc
             env: prod
+          - app: bcda
+            env: prod
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform

--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - .github/workflows/api-waf-apply.yml
+      - .github/workflows/api-waf-*
       - terraform/services/api-waf/**
       - terraform/modules/firewall/**
   workflow_dispatch: # Allow manual trigger
@@ -23,10 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [bcda, dpc]
-        env: [dev, test, sbx]
-        include:
-          - app: dpc
-            env: prod
+        env: [dev, test, sbx, prod]
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform

--- a/.github/workflows/api-waf-plan.yml
+++ b/.github/workflows/api-waf-plan.yml
@@ -3,7 +3,7 @@ name: api-waf plan terraform
 on:
   pull_request:
     paths:
-      - .github/workflows/api-waf-plan.yml
+      - .github/workflows/api-waf-*
       - terraform/services/api-waf/**
       - terraform/modules/firewall/**
   workflow_dispatch: # Allow manual trigger


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-634

## 🛠 Changes

Adds BCDA PROD to environment matrix for the shared WAF module rollout.

## ℹ️ Context

This will enable the WAF in the PROD environment and filter all incoming traffic.

## 🧪 Validation

After https://github.com/CMSgov/bcda-ops/pull/1128 is merged, we should be able to merge this PR to enable the WAF module in production. I'll then check for traffic/connection issues, and fail forward (create new PRs to address) if necessary.
