### PR TITLE
Bump DPC rate limit

### DIFF
--- a/terraform/modules/firewall/variables.tf
+++ b/terraform/modules/firewall/variables.tf
@@ -48,7 +48,7 @@ variable "content_type" {
 variable "rate_limit" {
   description = "IP rate limit for every 5 minutes"
   type        = number
-  default     = 300
+  default     = 3000
 }
 
 variable "ip_sets" {

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -52,6 +52,7 @@ module "aws_waf" {
   content_type = "APPLICATION_JSON"
 
   associated_resource_arn = data.aws_lb.api.arn
+  rate_limit = var.app == "dpc" ? 3000 : 300
   ip_sets = var.env == "sbx" ? [] : [
     one(data.aws_wafv2_ip_set.external_services).arn,
     one(aws_wafv2_ip_set.api_customers).arn,

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -52,7 +52,7 @@ module "aws_waf" {
   content_type = "APPLICATION_JSON"
 
   associated_resource_arn = data.aws_lb.api.arn
-  rate_limit = var.app == "dpc" ? 3000 : 300
+  rate_limit              = var.app == "dpc" ? 3000 : 300
   ip_sets = var.env == "sbx" ? [] : [
     one(data.aws_wafv2_ip_set.external_services).arn,
     one(aws_wafv2_ip_set.api_customers).arn,

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -52,7 +52,7 @@ module "aws_waf" {
   content_type = "APPLICATION_JSON"
 
   associated_resource_arn = data.aws_lb.api.arn
-  rate_limit              = var.app == "dpc" ? 3000 : 300
+  rate_limit              = var.app == "bcda" ? 300 : 3000
   ip_sets = var.env == "sbx" ? [] : [
     one(data.aws_wafv2_ip_set.external_services).arn,
     one(aws_wafv2_ip_set.api_customers).arn,


### PR DESCRIPTION
## 🎫 Ticket

https://cmsgov.slack.com/archives/C04UG13JF9B/p1733939290774959

## 🛠 Changes

Bumping DPC rate limit to 3000requests/5min

## ℹ️ Context

DPC is seeing some customers get timed out

## 🧪 Validation

DPC rate limit rule should be changed, all others should stay the same
