### PR TITLE
PLT-820: Increase BCDA rate limit to 3000

### DIFF
--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -52,6 +52,7 @@ module "aws_waf" {
   content_type = "APPLICATION_JSON"
 
   associated_resource_arn = data.aws_lb.api.arn
+  rate_limit              = var.app == "bcda" ? 1000 : 3000
   ip_sets = var.env == "sbx" ? [] : [
     one(data.aws_wafv2_ip_set.external_services).arn,
     one(aws_wafv2_ip_set.api_customers).arn,

--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -52,7 +52,6 @@ module "aws_waf" {
   content_type = "APPLICATION_JSON"
 
   associated_resource_arn = data.aws_lb.api.arn
-  rate_limit              = var.app == "bcda" ? 300 : 3000
   ip_sets = var.env == "sbx" ? [] : [
     one(data.aws_wafv2_ip_set.external_services).arn,
     one(aws_wafv2_ip_set.api_customers).arn,


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-820

## 🛠 Changes

Removed the line making BCDA's limit 1000/5min

## ℹ️ Context

https://cmsgov.slack.com/archives/CHG7Q7XNH/p1734444527725299?thread_ts=1734019554.318099&cid=CHG7Q7XNH

> @ Grant Freeman let's 10x BCDA's rate limit from 300 requests / 5 minutes to 3000 requests / 5 minutes to match DPC. This will help us:
> 1. meet the needs for Maryland TCoC above (many file downloads for 1 entity)
> 1. address a previous request from Aledade (many entities for 1 IP address)

After discussion with the BCDA team, we decided on 1000requests / 5 minutes instead.

## 🧪 Validation

This should be verifiable by checking the rate limit rule no the BCDA WAFs
