### PR TITLE
PLT-832: Update upload-artifacts from v3 to v4

### DIFF
--- a/.github/workflows/aws-params-env-action-check-dist.yml
+++ b/.github/workflows/aws-params-env-action-check-dist.yml
@@ -46,7 +46,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/aws-params-env-action-check-dist.yml
+++ b/.github/workflows/aws-params-env-action-check-dist.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'actions/aws-params-env-action/**'
       - '!actions/aws-params-env-action/**.md'
+      - .github/workflows/aws-params-env-action-check-dist.yml
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-832

## 🛠 Changes

Changed upload-artifacts version to v4.

## ℹ️ Context

The current upload-artifacts version is being sunset, so we will have to update the version to v4.

## 🧪 Validation

Workflow should run without failures
