### PR TITLE
PLT-851 Add repos to github-actions-role

### DIFF
--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -11,10 +11,13 @@ locals {
     bcda = [
       "repo:CMSgov/ab2d-bcda-dpc-platform:*",
       "repo:CMSgov/bcda-app:*",
+      "repo:CMSgov/bcda-ssas-app:*",
+      "repo:CMSgov/bcda-static-site:*",
     ]
     dpc = [
       "repo:CMSgov/ab2d-bcda-dpc-platform:*",
       "repo:CMSgov/dpc-app:*",
+      "repo:CMSgov/dpc-static-site:*",
     ]
   }
   admin_app = var.app == "dpc" ? "bcda" : var.app


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-851

## 🛠 Changes

Added repos for github-actions-role permissions.

## ℹ️ Context

In creating workflows for the bcda-ssas-app repo, the BCDA team found they could not assume the github actions IAM roles in our accounts. I noticed the bcda-static-site and dpc-static-site repos were also missing from the list, so added those as well in anticipation of workflows there.

## 🧪 Validation

See checks for terraform plans.