### PR TITLE
PLT-853 add fix for openssl

### DIFF
--- a/packer/github-actions-runner/install-runner.sh
+++ b/packer/github-actions-runner/install-runner.sh
@@ -42,3 +42,25 @@ echo "Un-tar action runner"
 tar xzf ./$file_name
 echo "Delete tar file"
 rm -rf $file_name
+
+# Workaround to modify /etc/pki/tls/openssl.cnf
+echo "Applying workaround to /etc/pki/tls/openssl.cnf"
+sudo sed -i 's/^openssl_conf = openssl_init/openssl_conf = default_conf/' /etc/pki/tls/openssl.cnf
+
+sudo tee -a /etc/pki/tls/openssl.cnf > /dev/null <<EOL
+
+[default_conf]
+ssl_conf = ssl_section
+
+[ssl_section]
+system_default = system_default_section
+
+[system_default_section]
+providers = provider_sect
+ssl_conf = ssl_module
+MaxProtocol = TLSv1.2
+CipherString = ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:...
+Ciphersuites =
+EOL
+
+echo "Workaround applied successfully."


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-853

## 🛠 Changes

Adding a change to the github runner install script to fix openssl issue

## ℹ️ Context

We are receiving errors during curls 

* Closing connection
curl: (35) OpenSSL/3.0.8: error:1C8000E9:Provider routines::ems not enabled 

## 🧪 Validation

This was tested 
