### PR TITLE
BCDA-8626: Add supporting terraform for new BCDA lambda

### DIFF
--- a/.github/workflows/admin-aco-deny-apply.yml
+++ b/.github/workflows/admin-aco-deny-apply.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [dev]
+        env: [dev, test, prod]
     env:
       TF_VAR_env: ${{ matrix.env }}
       TF_VAR_app: bcda

--- a/.github/workflows/admin-aco-deny-apply.yml
+++ b/.github/workflows/admin-aco-deny-apply.yml
@@ -1,0 +1,50 @@
+name: Admin ACO Deny apply terraform
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/admin-aco-deny-apply.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/admin-aco-deny/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  terraform-apply:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/admin-aco-deny
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev]
+    env:
+      TF_VAR_env: ${{ matrix.env }}
+      TF_VAR_app: bcda
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/bcda-$TF_VAR_env.s3.tfbackend
+      - run: terraform apply -auto-approve
+      - uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'C04UG13JF9B'
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+

--- a/.github/workflows/admin-aco-deny-plan.yml
+++ b/.github/workflows/admin-aco-deny-plan.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [dev]
+        env: [dev, test, prod]
     env:
       TF_VAR_env: ${{ matrix.env }}
       TF_VAR_app: bcda

--- a/.github/workflows/admin-aco-deny-plan.yml
+++ b/.github/workflows/admin-aco-deny-plan.yml
@@ -1,0 +1,48 @@
+name: Admin ACO Deny plan terraform
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/admin-aco-deny-plan.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/admin-aco-deny/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  check-terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/admin-aco-deny
+
+  terraform-plan:
+    needs: check-terraform-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/admin-aco-deny
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev]
+    env:
+      TF_VAR_env: ${{ matrix.env }}
+      TF_VAR_app: bcda
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/bcda-$TF_VAR_env.s3.tfbackend
+      - run: terraform plan

--- a/.github/workflows/api-waf-sync-apply.yml
+++ b/.github/workflows/api-waf-sync-apply.yml
@@ -29,6 +29,11 @@ jobs:
       matrix:
         env: [dev]
         app: [bcda, dpc]
+        include:
+          - app: bcda
+            env: prod
+          - app: bcda
+            env: test
     env:
       TF_VAR_env: ${{ matrix.env }}
       TF_VAR_app: ${{ matrix.app }}

--- a/.github/workflows/api-waf-sync-plan.yml
+++ b/.github/workflows/api-waf-sync-plan.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [dev]
+        env: [dev, test, prod]
         app: [bcda, dpc]
     env:
       TF_VAR_env: ${{ matrix.env }}

--- a/terraform/services/admin-aco-deny/README.md
+++ b/terraform/services/admin-aco-deny/README.md
@@ -1,0 +1,16 @@
+# Terraform for Admin ACO Deny function and associated infra
+
+This service sets up the infrastructure for the Admin ACO Deny lambda function in upper and lower environments for BCDA.
+
+## Manual deploy
+
+Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
+
+```bash
+terraform init -backend-config=../../backends/bcda-dev.s3.tfbackend
+terraform apply
+```
+
+## Automated deploy
+
+This terraform is automatically applied on merge to main by the admin-aco-deny-apply.yml workflow.

--- a/terraform/services/admin-aco-deny/main.tf
+++ b/terraform/services/admin-aco-deny/main.tf
@@ -1,0 +1,41 @@
+locals {
+  full_name   = "${var.app}-${var.env}-admin-aco-deny"
+  db_sg_name  = "bcda-${var.env}-rds"
+  memory_size = 2048
+}
+
+module "admin_aco_deny_function" {
+  source = "../../modules/function"
+
+  app = var.app
+  env = var.env
+
+  name        = local.full_name
+  description = "Denies access to BCDA for supplied ACO IDs"
+
+  handler = "bootstrap"
+  runtime = "provided.al2"
+
+  memory_size = local.memory_size
+
+  environment_variables = {
+    ENV      = var.env
+    APP_NAME = "${var.app}-${var.env}-admin-aco-deny"
+  }
+}
+
+# Add a rule to the database security group to allow access from the function
+data "aws_security_group" "db" {
+  name = local.db_sg_name
+}
+
+resource "aws_security_group_rule" "function_access" {
+  type        = "ingress"
+  from_port   = 5432
+  to_port     = 5432
+  protocol    = "tcp"
+  description = "admin-aco-deny function access"
+
+  security_group_id        = data.aws_security_group.db.id
+  source_security_group_id = module.admin_aco_deny_function.security_group_id
+}

--- a/terraform/services/admin-aco-deny/outputs.tf
+++ b/terraform/services/admin-aco-deny/outputs.tf
@@ -1,0 +1,7 @@
+output "function_role_arn" {
+  value = module.admin_aco_deny.role_arn
+}
+
+output "zip_bucket" {
+  value = module.admin_aco_deny.zip_bucket
+}

--- a/terraform/services/admin-aco-deny/outputs.tf
+++ b/terraform/services/admin-aco-deny/outputs.tf
@@ -1,7 +1,7 @@
 output "function_role_arn" {
-  value = module.admin_aco_deny.role_arn
+  value = module.admin_aco_deny_function.role_arn
 }
 
 output "zip_bucket" {
-  value = module.admin_aco_deny.zip_bucket
+  value = module.admin_aco_deny_function.zip_bucket
 }

--- a/terraform/services/admin-aco-deny/terraform.tf
+++ b/terraform/services/admin-aco-deny/terraform.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      application = var.app
+      business    = "oeda"
+      code        = "https://github.com/CMSgov/ab2d-bcda-dpc-platform/tree/main/terraform/services/admin-aco-deny"
+      component   = "admin-aco-deny"
+      environment = var.env
+      terraform   = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "admin-aco-deny/terraform.tfstate"
+  }
+}

--- a/terraform/services/admin-aco-deny/variables.tf
+++ b/terraform/services/admin-aco-deny/variables.tf
@@ -1,0 +1,17 @@
+variable "app" {
+  description = "The application name (bcda)"
+  type        = string
+  validation {
+    condition     = contains(["bcda"], var.app)
+    error_message = "Valid value for app is bcda."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, or prod."
+  }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8626

## 🛠 Changes

Add supporting terraform for new BCDA lambda (admin task Deny ACOs), mostly copy pasted from similar lambdas.

## ℹ️ Context

New BCDA lambda.  Part of the move from jenkins.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local terraform lint
