### PR TITLE
Increase memory for dpc opt out export lambda

### DIFF
--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -31,7 +31,7 @@ locals {
   memory_size = {
     ab2d = 10240
     bcda = null
-    dpc  = 1024
+    dpc  = 2048
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4460

## 🛠 Changes

Configuration of dpc opt out export memory changed from 1024 to 2048

## ℹ️ Context

Our lambda on prod started failing with `Error: Runtime exited with error: signal: killed`, and manually increasing to 2048 fixed it.

## 🧪 Validation

Upped manually; lambda has run successfully since.
