### PR TITLE
PLT-864: ADD IPv6 IP-set for BCDA non-SBX environments

### DIFF
--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -41,6 +41,7 @@ resource "aws_wafv2_ip_set" "api_customers" {
 }
 
 resource "aws_wafv2_ip_set" "ipv6_api_customers" {
+  count              = local.is_sandbox ? 0 : 1
   name               = "${var.app}-${var.env}-ipv6-api-customers"
   description        = "IP ranges for customers of this API"
   scope              = "REGIONAL"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-864

## 🛠 Changes
Adds a new IP set for BCDA environments and cleans up some repeated conditionals with a variable

## ℹ️ Context

BCDA team was running into issues deploying their new WAF sync lambda due to our IP set not allowing IPv6 addresses.

[Relevant slack thread.](https://cmsgov.slack.com/archives/C04UG13JF9B/p1737139629675179)

## 🧪 Validation
BCDA should be able to add IPv6 addresses to this IP set after release.
