### PR TITLE
PLT-754 Ensure runner runs as root

### DIFF
--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -99,6 +99,9 @@ module "github-actions-runner" {
   # Defaults to 5 minutes
   runner_boot_time_in_minutes = 10
 
+  # Run as root to avoid https://github.com/actions/checkout/issues/956
+  runner_as_root = true
+
   runner_iam_role_managed_policy_arns  = [aws_iam_policy.runner.arn]
   runner_additional_security_group_ids = [data.aws_security_group.vpn.id]
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-754

## 🛠 Changes

Ensure the runner container runs as root.

## ℹ️ Context

As noted in https://github.com/actions/checkout/issues/956, GitHub still expects runner containers to run as root. Permissions around the actions/checkout step break in a number of ways if this is not set.

## 🧪 Validation

Will apply and test in the job currently failing on https://github.com/CMSgov/bcda-app/pull/1031.