### PR TITLE
Increase size of EBS volumes on GHA Runners

### DIFF
--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -63,11 +63,10 @@ module "github-actions-runner" {
     webhook_secret = var.webhook_secret
   }
 
-  # match the volume size of the source AMI snapshot
   block_device_mappings = [{
     device_name           = "/dev/xvda"
     delete_on_termination = true
-    volume_size           = 31
+    volume_size           = 63
     encrypted             = true
   }]
 


### PR DESCRIPTION
## 🎫 Ticket

https://cmsgov.slack.com/archives/C04UG13JF9B/p1737999040128209

## 🛠 Changes

Increases the size of the volumes on the runners

## ℹ️ Context

DPC is having docker image build failures due to running into memory issues

## 🧪 Validation

DPC builds should pass after this is merged, we may see image snapshots start to increase in size as well
