### PR TITLE
PLT-884 Increase compute for GHA runners

### DIFF
--- a/packer/github-actions-runner/variables.pkr.hcl
+++ b/packer/github-actions-runner/variables.pkr.hcl
@@ -7,7 +7,7 @@ variable "region" {
 variable "instance_type" {
   description = "The instance type Packer will use for the builder"
   type        = string
-  default     = "t3.xlarge"
+  default     = "t3.large"
 }
 
 variable "ami_account" {

--- a/packer/github-actions-runner/variables.pkr.hcl
+++ b/packer/github-actions-runner/variables.pkr.hcl
@@ -7,7 +7,7 @@ variable "region" {
 variable "instance_type" {
   description = "The instance type Packer will use for the builder"
   type        = string
-  default     = "t3.large"
+  default     = "t3.xlarge"
 }
 
 variable "ami_account" {

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -106,7 +106,7 @@ module "github-actions-runner" {
 
   instance_target_capacity_type = "on-demand"
   instance_types = [
-    "t3.large",
+    "t3.xlarge",
   ]
 
   enable_ami_housekeeper = true


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-884

## 🛠 Changes

Changes instance size for runners to t3.xlarge

## ℹ️ Context

Application engineers expect self-hosted runners to match github-hosted runners for compute.

## 🧪 Validation

See terraform plan in checks, and see apply on merge to ensure successful infra update.