### PR TITLE
PLT-884: Add config for block storage for GHA runner AMI

### DIFF
--- a/packer/github-actions-runner/sources.pkr.hcl
+++ b/packer/github-actions-runner/sources.pkr.hcl
@@ -32,6 +32,14 @@ source "amazon-ebs" "github-actions-runner" {
   # Enforces IMDSv2 support on the resulting AMI
   imds_support = "v2.0"
 
+  # Ensures the launched runner instances use the full volumes
+  launch_block_device_mappings {
+    device_name           = "/dev/xvda"
+    volume_size           = 63
+    delete_on_termination = true
+    encrypted             = true
+  }
+
   tags = {
     Name          = "github-actions-runner-ami",
     Base_AMI_Name = "{{ .SourceAMIName }}"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-884

## 🛠 Changes

Specifies volume size for GHA runner AMIs

## ℹ️ Context

We are still not utilizing the full disk space of the runners. This change will double the spacce and potentially unblock the jobs that are seeing disk usage errors.

## 🧪 Validation

Workflows utilizing the GHA runners should no longer fail due to storage errors.
