### PR TITLE
PLT-895: Increase Concurrent GHA Runners

### DIFF
--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -74,6 +74,8 @@ module "github-actions-runner" {
   runner_binaries_syncer_lambda_zip = "lambdas-download/runner-binaries-syncer.zip"
   runners_lambda_zip                = "lambdas-download/runners.zip"
   ami_housekeeper_lambda_zip        = "lambdas-download/ami-housekeeper.zip"
+  # Increases concurrent runners from 3 (default)
+  runners_maximum_count             = 12
 
   ami_owners = [var.ami_account]
   ami_filter = {

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -75,7 +75,7 @@ module "github-actions-runner" {
   runners_lambda_zip                = "lambdas-download/runners.zip"
   ami_housekeeper_lambda_zip        = "lambdas-download/ami-housekeeper.zip"
   # Increases concurrent runners from 3 (default)
-  runners_maximum_count             = 12
+  runners_maximum_count = 12
 
   ami_owners = [var.ami_account]
   ami_filter = {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-895

## 🛠 Changes

Overrides the default 3 concurrent runners to 12 to allow for long-running jobs to not block runners being assigned.

## ℹ️ Context

See relevant slack thread: https://cmsgov.slack.com/archives/C04UG13JF9B/p1738176789390989?thread_ts=1737999040.128209&cid=C04UG13JF9B

This should allow for workflows with multiple jobs to be run in parallel without blocking.

## 🧪 Validation

Teams should see their runners pick up more jobs in workflows.
