### PR TITLE
BCDA-8630: Add create admin ACO creds service and workflows

### DIFF
--- a/.github/workflows/admin-aco-deny-apply.yml
+++ b/.github/workflows/admin-aco-deny-apply.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [dev, test, prod]
+        env: [dev, test, sbx, prod]
     env:
       TF_VAR_env: ${{ matrix.env }}
       TF_VAR_app: bcda

--- a/.github/workflows/admin-aco-deny-plan.yml
+++ b/.github/workflows/admin-aco-deny-plan.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [dev, test, prod]
+        env: [dev, test, sbx, prod]
     env:
       TF_VAR_env: ${{ matrix.env }}
       TF_VAR_app: bcda

--- a/.github/workflows/admin-create-aco-creds-apply.yml
+++ b/.github/workflows/admin-create-aco-creds-apply.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [dev, test, prod]
+        env: [dev, test, sbx, prod]
     env:
       TF_VAR_env: ${{ matrix.env }}
       TF_VAR_app: bcda

--- a/.github/workflows/admin-create-aco-creds-apply.yml
+++ b/.github/workflows/admin-create-aco-creds-apply.yml
@@ -1,0 +1,50 @@
+name: Admin Create ACO Credentials apply terraform
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/admin-create-aco-creds-apply.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/admin-create-aco-creds/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  terraform-apply:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/admin-create-aco-creds
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev, test, prod]
+    env:
+      TF_VAR_env: ${{ matrix.env }}
+      TF_VAR_app: bcda
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/bcda-$TF_VAR_env.s3.tfbackend
+      - run: terraform apply -auto-approve
+      - uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: 'C04UG13JF9B'
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+

--- a/.github/workflows/admin-create-aco-creds-plan.yml
+++ b/.github/workflows/admin-create-aco-creds-plan.yml
@@ -1,0 +1,48 @@
+name: Admin Create ACO Creds plan terraform
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/admin-create-aco-creds-plan.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/admin-create-aco-creds/**
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  check-terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/admin-create-aco-creds
+
+  terraform-plan:
+    needs: check-terraform-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/admin-create-aco-creds
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev, test, prod]
+    env:
+      TF_VAR_env: ${{ matrix.env }}
+      TF_VAR_app: bcda
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/bcda-$TF_VAR_env.s3.tfbackend
+      - run: terraform plan

--- a/.github/workflows/admin-create-aco-creds-plan.yml
+++ b/.github/workflows/admin-create-aco-creds-plan.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [dev, test, prod]
+        env: [dev, test, sbx, prod]
     env:
       TF_VAR_env: ${{ matrix.env }}
       TF_VAR_app: bcda

--- a/terraform/services/admin-aco-deny/main.tf
+++ b/terraform/services/admin-aco-deny/main.tf
@@ -1,7 +1,7 @@
 locals {
   full_name   = "${var.app}-${var.env}-admin-aco-deny"
   db_sg_name  = "bcda-${var.env}-rds"
-  memory_size = 2048
+  memory_size = 256
 }
 
 module "admin_aco_deny_function" {

--- a/terraform/services/admin-aco-deny/variables.tf
+++ b/terraform/services/admin-aco-deny/variables.tf
@@ -8,10 +8,10 @@ variable "app" {
 }
 
 variable "env" {
-  description = "The application environment (dev, test, prod)"
+  description = "The application environment (dev, test, sbx, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "prod"], var.env)
-    error_message = "Valid value for env is dev, test, or prod."
+    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, sbx, or prod."
   }
 }

--- a/terraform/services/admin-create-aco-creds/README.md
+++ b/terraform/services/admin-create-aco-creds/README.md
@@ -1,4 +1,4 @@
-# Terraform for Admin ACO Deny function and associated infra
+# Terraform for Admin Create ACO Credentials function and associated infra
 
 This service sets up the infrastructure for the Admin Create ACO Credentials lambda function in upper and lower environments for BCDA.
 

--- a/terraform/services/admin-create-aco-creds/README.md
+++ b/terraform/services/admin-create-aco-creds/README.md
@@ -1,0 +1,16 @@
+# Terraform for Admin ACO Deny function and associated infra
+
+This service sets up the infrastructure for the Admin Create ACO Credentials lambda function in upper and lower environments for BCDA.
+
+## Manual deploy
+
+Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
+
+```bash
+terraform init -backend-config=../../backends/bcda-dev.s3.tfbackend
+terraform apply
+```
+
+## Automated deploy
+
+This terraform is automatically applied on merge to main by the admin-create-aco-creds-apply.yml workflow.

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 data "aws_ssm_parameter" "aco_creds_bucket_role_arn" {
-  name = "arn:aws:s3:::bcda-aco-credentials/${var.env}"
+  name = "arn:aws:s3:::bcda-aco-credentials/*"
 }
 
 data "aws_iam_policy_document" "assume_bucket_role" {

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -4,14 +4,10 @@ locals {
   memory_size = 256
 }
 
-data "aws_ssm_parameter" "aco_creds_bucket_role_arn" {
-  name = "arn:aws:s3:::bcda-aco-credentials/*"
-}
-
-data "aws_iam_policy_document" "assume_bucket_role" {
+data "aws_iam_policy_document" "creds_bucket" {
   statement {
     actions   = ["s3:PutObject"]
-    resources = [data.aws_ssm_parameter.aco_creds_bucket_role_arn.value]
+    resources = ["arn:aws:s3:::bcda-aco-credentials/${var.env == "sbx" ? "opensbx" : var.env}/*"]
   }
 }
 
@@ -30,7 +26,7 @@ module "admin_create_aco_creds_function" {
   memory_size = local.memory_size
 
   function_role_inline_policies = {
-    assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json
+    assume-bucket-role = data.aws_iam_policy_document.creds_bucket.json
   }
 
   environment_variables = {

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -1,0 +1,41 @@
+locals {
+  full_name   = "${var.app}-${var.env}-admin-create-aco-creds"
+  db_sg_name  = "bcda-${var.env}-rds"
+  memory_size = 2048
+}
+
+module "admin_create_aco_creds_function" {
+  source = "../../modules/function"
+
+  app = var.app
+  env = var.env
+
+  name        = local.full_name
+  description = "Finds and Creates ACO Credentials for passed in ACO ID and IP addresses"
+
+  handler = "bootstrap"
+  runtime = "provided.al2"
+
+  memory_size = local.memory_size
+
+  environment_variables = {
+    ENV      = var.env
+    APP_NAME = "${var.app}-${var.env}-admin-create-aco-creds"
+  }
+}
+
+# Add a rule to the database security group to allow access from the function
+data "aws_security_group" "db" {
+  name = local.db_sg_name
+}
+
+resource "aws_security_group_rule" "function_access" {
+  type        = "ingress"
+  from_port   = 5432
+  to_port     = 5432
+  protocol    = "tcp"
+  description = "admin-create-aco-creds function access"
+
+  security_group_id        = data.aws_security_group.db.id
+  source_security_group_id = module.admin_create_aco_creds_function.security_group_id
+}

--- a/terraform/services/admin-create-aco-creds/outputs.tf
+++ b/terraform/services/admin-create-aco-creds/outputs.tf
@@ -1,0 +1,7 @@
+output "function_role_arn" {
+  value = module.admin_create_aco_creds_function.role_arn
+}
+
+output "zip_bucket" {
+  value = module.admin_create_aco_creds_function.zip_bucket
+}

--- a/terraform/services/admin-create-aco-creds/terraform.tf
+++ b/terraform/services/admin-create-aco-creds/terraform.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      application = var.app
+      business    = "oeda"
+      code        = "https://github.com/CMSgov/ab2d-bcda-dpc-platform/tree/main/terraform/services/admin-create-aco-creds"
+      component   = "admin-create-aco-creds"
+      environment = var.env
+      terraform   = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "admin-create-aco-creds/terraform.tfstate"
+  }
+}

--- a/terraform/services/admin-create-aco-creds/variables.tf
+++ b/terraform/services/admin-create-aco-creds/variables.tf
@@ -1,0 +1,17 @@
+variable "app" {
+  description = "The application name (bcda)"
+  type        = string
+  validation {
+    condition     = contains(["bcda"], var.app)
+    error_message = "Valid value for app is bcda."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, sbx, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, sbx, or prod."
+  }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8630

## 🛠 Changes

Add BCDA service and workflows for Admin Create ACO Credentials lambda.

## ℹ️ Context

Part of moving off jenkins.  This service supports the BCDA Admin Create ACO Credentials lambda which creates a credentials file for an ACO in s3.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

TF validation script.
