### PR TITLE
BCDA-8629: Add infrastructure for Create ACO Admin Task

### DIFF
--- a/.github/workflows/admin-create-aco-apply.yml
+++ b/.github/workflows/admin-create-aco-apply.yml
@@ -1,0 +1,48 @@
+name: Admin Create ACO apply terraform
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/admin-create-aco-apply.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/admin-create-aco/**
+  workflow_dispatch: # Allow manual trigger
+jobs:
+  terraform-apply:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/admin-create-aco
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev, test, sbx, prod]
+    env:
+      TF_VAR_env: ${{ matrix.env }}
+      TF_VAR_app: bcda
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/bcda-$TF_VAR_env.s3.tfbackend
+      - run: terraform apply -auto-approve
+      - uses: slackapi/slack-github-action@v1.26.0
+        if: ${{ failure() }}
+        with:
+          channel-id: "C04UG13JF9B"
+          slack-message: "Terraform apply failure: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/admin-create-aco-plan.yml
+++ b/.github/workflows/admin-create-aco-plan.yml
@@ -1,0 +1,46 @@
+name: Admin Create ACO plan terraform
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/admin-create-aco-plan.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/admin-create-aco/**
+  workflow_dispatch: # Allow manual trigger
+jobs:
+  check-terraform-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/admin-create-aco
+  terraform-plan:
+    needs: check-terraform-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./terraform/services/admin-create-aco
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev, test, sbx, prod]
+    env:
+      TF_VAR_env: ${{ matrix.env }}
+      TF_VAR_app: bcda
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -reconfigure -backend-config=../../backends/bcda-$TF_VAR_env.s3.tfbackend
+      - run: terraform plan

--- a/terraform/services/admin-create-aco/README.md
+++ b/terraform/services/admin-create-aco/README.md
@@ -1,0 +1,16 @@
+# Terraform for Admin Create ACO function and associated infra
+
+This service sets up the infrastructure for the Admin Create ACO lambda function in upper and lower environments for BCDA.
+
+## Manual deploy
+
+Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
+
+```bash
+terraform init -backend-config=../../backends/bcda-dev.s3.tfbackend
+terraform apply
+```
+
+## Automated deploy
+
+This terraform is automatically applied on merge to main by the admin-create-aco-apply.yml workflow.

--- a/terraform/services/admin-create-aco/main.tf
+++ b/terraform/services/admin-create-aco/main.tf
@@ -1,7 +1,7 @@
 locals {
   full_name   = "${var.app}-${var.env}-admin-create-aco"
-  db_sg_name  = "bcda-${var.env}-rds"
-  memory_size = 2048
+  db_sg_name  = "bcda-${var.env == "sbx" ? "opensbx" : var.env}-rds"
+  memory_size = 256
 }
 
 module "admin_create_aco_function" {

--- a/terraform/services/admin-create-aco/main.tf
+++ b/terraform/services/admin-create-aco/main.tf
@@ -1,0 +1,41 @@
+locals {
+  full_name   = "${var.app}-${var.env}-admin-create-aco"
+  db_sg_name  = "bcda-${var.env}-rds"
+  memory_size = 2048
+}
+
+module "admin_create_aco_function" {
+  source = "../../modules/function"
+
+  app = var.app
+  env = var.env
+
+  name        = local.full_name
+  description = "Creates an ACO for BCDA."
+
+  handler = "bootstrap"
+  runtime = "provided.al2"
+
+  memory_size = local.memory_size
+
+  environment_variables = {
+    ENV      = var.env
+    APP_NAME = "${var.app}-${var.env}-admin-create-aco"
+  }
+}
+
+# Add a rule to the database security group to allow access from the function
+data "aws_security_group" "db" {
+  name = local.db_sg_name
+}
+
+resource "aws_security_group_rule" "function_access" {
+  type        = "ingress"
+  from_port   = 5432
+  to_port     = 5432
+  protocol    = "tcp"
+  description = "admin-create-aco function access"
+
+  security_group_id        = data.aws_security_group.db.id
+  source_security_group_id = module.admin_create_aco_function.security_group_id
+}

--- a/terraform/services/admin-create-aco/outputs.tf
+++ b/terraform/services/admin-create-aco/outputs.tf
@@ -1,0 +1,7 @@
+output "function_role_arn" {
+  value = module.admin_create_aco_function.role_arn
+}
+
+output "zip_bucket" {
+  value = module.admin_create_aco_function.zip_bucket
+}

--- a/terraform/services/admin-create-aco/terraform.tf
+++ b/terraform/services/admin-create-aco/terraform.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      application = var.app
+      business    = "oeda"
+      code        = "https://github.com/CMSgov/ab2d-bcda-dpc-platform/tree/main/terraform/services/admin-create-aco"
+      component   = "admin-create-aco"
+      environment = var.env
+      terraform   = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "admin-create-aco/terraform.tfstate"
+  }
+}

--- a/terraform/services/admin-create-aco/variables.tf
+++ b/terraform/services/admin-create-aco/variables.tf
@@ -8,10 +8,10 @@ variable "app" {
 }
 
 variable "env" {
-  description = "The application environment (dev, test, opensbx, prod)"
+  description = "The application environment (dev, test, sbx, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "opensbx", "prod"], var.env)
+    condition     = contains(["dev", "test", "sbx", "prod"], var.env)
     error_message = "Valid value for env is dev, test, opensbx or prod."
   }
 }

--- a/terraform/services/admin-create-aco/variables.tf
+++ b/terraform/services/admin-create-aco/variables.tf
@@ -12,6 +12,6 @@ variable "env" {
   type        = string
   validation {
     condition     = contains(["dev", "test", "sbx", "prod"], var.env)
-    error_message = "Valid value for env is dev, test, opensbx or prod."
+    error_message = "Valid value for env is dev, test, sbx or prod."
   }
 }

--- a/terraform/services/admin-create-aco/variables.tf
+++ b/terraform/services/admin-create-aco/variables.tf
@@ -8,10 +8,10 @@ variable "app" {
 }
 
 variable "env" {
-  description = "The application environment (dev, test, prod)"
+  description = "The application environment (dev, test, opensbx, prod)"
   type        = string
   validation {
-    condition     = contains(["dev", "test", "prod"], var.env)
-    error_message = "Valid value for env is dev, test, or prod."
+    condition     = contains(["dev", "test", "opensbx", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, opensbx or prod."
   }
 }

--- a/terraform/services/admin-create-aco/variables.tf
+++ b/terraform/services/admin-create-aco/variables.tf
@@ -1,0 +1,17 @@
+variable "app" {
+  description = "The application name (bcda)"
+  type        = string
+  validation {
+    condition     = contains(["bcda"], var.app)
+    error_message = "Valid value for app is bcda."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, or prod."
+  }
+}


### PR DESCRIPTION
In order for BCDA to move off of Jenkins we need a new lambda to handle the admin task of Create ACO. This terraform service will handle the IaC side.

## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8629

## 🛠 Changes

Added a new service for the platform

## ℹ️ Context

Infrastructure needed to be made in order to handle the new lambda.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Terraform plan
