### PR TITLE
PLT-905: Add Docker Compose install to packer build for GHA runners

### DIFF
--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -17,8 +17,9 @@ build {
     remote_folder = "/home/ec2-user/"
     inline = [
       "sudo dnf install -y amazon-cloudwatch-agent jq git docker libicu curl",
-      "sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose",
-      "sudo chmod +x /usr/local/bin/docker-compose",
+      "mkdir -p /usr/local/lib/docker/cli-plugins"
+      "sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose",
+      "sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose",
       "sudo dnf install -y https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm",
       "sudo systemctl enable docker.service",
       "sudo systemctl enable containerd.service",

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -17,7 +17,7 @@ build {
     remote_folder = "/home/ec2-user/"
     inline = [
       "sudo dnf install -y amazon-cloudwatch-agent jq git docker libicu curl",
-      "mkdir -p /usr/local/lib/docker/cli-plugins"
+      "mkdir -p /usr/local/lib/docker/cli-plugins",
       "sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose",
       "sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose",
       "sudo dnf install -y https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm",

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -17,6 +17,8 @@ build {
     remote_folder = "/home/ec2-user/"
     inline = [
       "sudo dnf install -y amazon-cloudwatch-agent jq git docker libicu curl",
+      "sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose",
+      "sudo chmod +x /usr/local/bin/docker-compose",
       "sudo dnf install -y https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm",
       "sudo systemctl enable docker.service",
       "sudo systemctl enable containerd.service",

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -17,7 +17,7 @@ build {
     remote_folder = "/home/ec2-user/"
     inline = [
       "sudo dnf install -y amazon-cloudwatch-agent jq git docker libicu curl",
-      "mkdir -p /usr/local/lib/docker/cli-plugins",
+      "sudo mkdir -p /usr/local/lib/docker/cli-plugins",
       "sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/lib/docker/cli-plugins/docker-compose",
       "sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose",
       "sudo dnf install -y https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm",


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-905

## 🛠 Changes

Adds installation commands for the latest release of docker compose for the GHA runners packer build.

## ℹ️ Context

Several teams use containerized tests in their workflows, this will allow them to run without requiring the teams to specify a docker compose installation in every workflow.

## 🧪 Validation

Compose should be installed by default on all runner images after this is merged and applied.
