### PR TITLE
Add kms access for lambda

### DIFF
--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -11,6 +11,13 @@ data "aws_iam_policy_document" "creds_bucket" {
   }
 }
 
+data "aws_iam_policy_document" "kms_access" {
+  statement {
+    actions   = ["kms:ListAliases"]
+    resources = ["arn:aws:s3:::bcda-aco-credentials/${var.env == "sbx" ? "opensbx" : var.env}/*"]
+  }
+}
+
 module "admin_create_aco_creds_function" {
   source = "../../modules/function"
 
@@ -27,6 +34,7 @@ module "admin_create_aco_creds_function" {
 
   function_role_inline_policies = {
     assume-bucket-role = data.aws_iam_policy_document.creds_bucket.json
+    assume-kms-role    = data.aws_iam_policy_document.kms_access.json
   }
 
   environment_variables = {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8630

## 🛠 Changes

Added kms:ListAliases role access for admin aco create creds lambda.

## ℹ️ Context

Part of moving off jenkins.  This lambda needs to access kms aliases in order to retrieve a specific keyID in order to allow access to put creds in a specific bucket.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Terraform fmt
