### PR TITLE
Add generate data key policy

### DIFF
--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -4,6 +4,10 @@ locals {
   memory_size = 256
 }
 
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
 data "aws_iam_policy_document" "creds_bucket" {
   statement {
     actions   = ["s3:PutObject"]
@@ -22,7 +26,7 @@ data "aws_iam_policy_document" "kms_access" {
 data "aws_iam_policy_document" "kms_generate" {
   statement {
     actions   = ["kms:GenerateDataKey"]
-    resources = ["arn:aws:kms:us-east-1:${data.aws_caller_identity.current.account_id}:alias/bcda-aco-creds-kms"]
+    resources = ["arn:aws:kms:${data.aws_region.current.account_id}:${data.aws_caller_identity.current.account_id}:alias/bcda-aco-creds-kms"]
   }
 }
 

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -19,6 +19,13 @@ data "aws_iam_policy_document" "kms_access" {
   }
 }
 
+data "aws_iam_policy_document" "kms_generate" {
+  statement {
+    actions   = ["kms:GenerateDataKey"]
+    resources = ["arn:aws:kms:us-east-1:${data.aws_caller_identity.current.account_id}:alias/bcda-aco-creds-kms"]
+  }
+}
+
 module "admin_create_aco_creds_function" {
   source = "../../modules/function"
 
@@ -34,8 +41,9 @@ module "admin_create_aco_creds_function" {
   memory_size = local.memory_size
 
   function_role_inline_policies = {
-    assume-bucket-role = data.aws_iam_policy_document.creds_bucket.json
-    assume-kms-role    = data.aws_iam_policy_document.kms_access.json
+    assume-bucket-role       = data.aws_iam_policy_document.creds_bucket.json
+    assume-kms-role          = data.aws_iam_policy_document.kms_access.json
+    assume-kms-generate-role = data.aws_iam_policy_document.kms_generate.json
   }
 
   environment_variables = {

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "kms_access" {
 data "aws_iam_policy_document" "kms_generate" {
   statement {
     actions   = ["kms:GenerateDataKey"]
-    resources = ["arn:aws:kms:${data.aws_region.current.account_id}:${data.aws_caller_identity.current.account_id}:alias/bcda-aco-creds-kms"]
+    resources = ["arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/bcda-aco-creds-kms"]
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-8630

## 🛠 Changes

Add kms GenerateDataKey policy to lambda.

## ℹ️ Context

This lambda needs to be able to securely put s3 objects.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Tf lint
