### PR TITLE
PLT-917: Changing runner machine type to m6a.xlarge for better performance

### DIFF
--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -108,7 +108,7 @@ module "github-actions-runner" {
 
   instance_target_capacity_type = "on-demand"
   instance_types = [
-    "t3.xlarge",
+    "m6i.xlarge",
   ]
 
   enable_ami_housekeeper = true

--- a/terraform/services/github-actions-runner/main.tf
+++ b/terraform/services/github-actions-runner/main.tf
@@ -108,7 +108,7 @@ module "github-actions-runner" {
 
   instance_target_capacity_type = "on-demand"
   instance_types = [
-    "m6i.xlarge",
+    "m6a.xlarge",
   ]
 
   enable_ami_housekeeper = true


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-917

## 🛠 Changes

The Github runner machine type was changed from t3.xlarge to m6i.xlarge.

## ℹ️ Context

As per the analysis documented in a comment on PLT-917 this change is being made in order to gain the benefits of significantly faster network speeds and also non-burstable CPU, which together should bring the overall execution time of workloads run on self-hosted runners closer to being on par with the execution times being observed when the same workloads are run on Github-hosted runners.

## 🧪 Validation

Validation so far has been to compare the documented specs of the t3.xlarge and m6i.xlarge and confirm the performance gains that can realized by changing the machine type.
