### PR TITLE
PLT-508: AB2D WAF IP Set Sync Workflow

### DIFF
--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         app: [ab2d]
-        env: [dev, test, prod]
+        env: [dev, test]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -1,0 +1,36 @@
+name: AB2D WAF IP Sets Sync
+
+on:
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  waf-ip-sync:
+    runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: ./scripts
+    strategy:
+      matrix:
+        app: [ab2d]
+        env: [dev, test, prod]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: CMSgov/cdap-private
+          ref: 'main'
+          sparse-checkout: ip_sets/ab2d/allowed_ips.txt
+          sparse-checkout-cone-mode: false
+          token: ${{ env.GITHUB_TOKEN }}
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-mgmt-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: bash waf-ip-set-sync.sh
+        env:
+          APP: ${{ matrix.app }}
+          ENV: ${{ matrix.env }}

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -28,7 +28,7 @@ jobs:
           token: ${{ env.GITHUB_TOKEN }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/bcda-mgmt-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - run: bash waf-ip-set-sync.sh
         env:

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Generating IP set"
+
+IPV4_LIST=$(grep -v '^#' allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
+
+echo "Fetching IP set IDs"
+
+{
+  read -r IPV4_SET_ID
+  read -r IPV6_SET_ID
+} < <(aws wafv2 list-ip-sets --scope REGIONAL | jq '.IPSets[] | select( .Name | contains("api-customers")) | .Id')
+
+echo "Updating IPv4 set"
+
+LOCK_TOKEN=$(aws wafv2 get-ip-set --name $APP-$ENV-api-customers --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq '.LockToken')
+
+aws wafv2 update-ip-set \
+  --name $APP-$ENV-api-customers \
+  --scope REGIONAL \
+  --id $IPV4_SET_ID \
+  --region us-east-1 \
+  --addresses $IPV4_LIST \
+  --lock-token $LOCK_TOKEN


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-508

## 🛠 Changes

Adds automation in the form of a workflow and associated script for automating AB2D WAF IP set updates.

## ℹ️ Context

AB2D needs an automated way to keep their IP sets up to date, this aims to do that. This workflow will eventually run on a cron schedule the team sees fit (likely daily/multiple times a day). The method is as follows (modeled off of the steps found [here](https://repost.aws/knowledge-center/maintain-waf-ipsets-using-cli)):

1. IPs are stored in the `cdap-private` repo.
2. Workflow is triggered by cron.
3. IPs are loaded into JSON that is digestible by AWS `update-ip-set` command. ([docs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/wafv2/update-ip-set.html))
4. Existing IP sets are fetched with `get-ip-set` to get a lock token needed for the update command. ([docs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/wafv2/get-ip-set.html))
5. Update command is then run with the lock token provided by the previous step.

## 🧪 Validation

Once merged, this workflow will automatically update the IP sets on a given schedule for all environments specified in the workflow file. (dev, test, prod)
