### PR TITLE
PLT-948: Bugfix for TF install action

### DIFF
--- a/actions/setup-tfenv-terraform/action.yml
+++ b/actions/setup-tfenv-terraform/action.yml
@@ -13,7 +13,7 @@ runs:
           git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
           echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
         else
-          echo "Teraform already initialized, skipping install"
+          echo "Terraform already initialized, skipping install"
         fi
       shell: bash
 

--- a/actions/setup-tfenv-terraform/action.yml
+++ b/actions/setup-tfenv-terraform/action.yml
@@ -9,8 +9,12 @@ runs:
   using: composite
   steps:
     - run: |
-        git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
-        echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
+        if ! tfenv --version; then
+          git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
+          echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
+        else
+          echo "Teraform already initialized, skipping install"
+        fi
       shell: bash
 
     - working-directory: ${{ inputs.directory }}

--- a/actions/setup-tfenv-terraform/action.yml
+++ b/actions/setup-tfenv-terraform/action.yml
@@ -9,11 +9,11 @@ runs:
   using: composite
   steps:
     - run: |
-        if ! tfenv --version; then
+        if tfenv --version; then
+          echo "tfenv already installed, skipping"
+        else
           git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
           echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
-        else
-          echo "Terraform already initialized, skipping install"
         fi
       shell: bash
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-948

## 🛠 Changes

Adds a check to see if TF is already installed on the machine before cloning.

## ℹ️ Context

[This thread](https://cmsgov.slack.com/archives/C04UG13JF9B/p1741287498094549) brought up an issue where the TF installation step was hitting errors because a prior run had already installed the necessary files. Git clone does not allow for overwriting, so the operation would fail with an error.

## 🧪 Validation
We should see runs no longer fail due to existing tfenv directories when using the installation action.
