### PR TITLE
PLT-948: Add clone to temp directory

### DIFF
--- a/actions/setup-tfenv-terraform/action.yml
+++ b/actions/setup-tfenv-terraform/action.yml
@@ -14,7 +14,6 @@ runs:
         else
           git clone --depth=1 https://github.com/tfutils/tfenv.git temp
           mv temp ~/.tfenv
-          rm -rf temp
           echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
         fi
       shell: bash

--- a/actions/setup-tfenv-terraform/action.yml
+++ b/actions/setup-tfenv-terraform/action.yml
@@ -12,8 +12,9 @@ runs:
         if tfenv --version; then
           echo "tfenv already installed, skipping"
         else
-          git clone --depth=1 https://github.com/tfutils/tfenv.git temp
-          mv temp ~/.tfenv
+          TMPDIR=$(mktemp -d)
+          git clone --depth=1 https://github.com/tfutils/tfenv.git $TMPDIR
+          mv $TMPDIR ~/.tfenv
           echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
         fi
       shell: bash

--- a/actions/setup-tfenv-terraform/action.yml
+++ b/actions/setup-tfenv-terraform/action.yml
@@ -12,7 +12,9 @@ runs:
         if tfenv --version; then
           echo "tfenv already installed, skipping"
         else
-          git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv
+          git clone --depth=1 https://github.com/tfutils/tfenv.git temp
+          mv temp ~/.tfenv
+          rm -rf temp
           echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
         fi
       shell: bash


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-948

## 🛠 Changes

Changes the git clone method to one where we clone to a temp directory to get around git clone's limitation of needing the directory to be empty

## ℹ️ Context

After implementing a fix where we check to see if tfenv is already installed, we were still getting errors with `git clone` because the directory already existed.

## 🧪 Validation

Workflows should pass and not be stopped by previous tfenv installations.
