### PR TITLE
PLT-508: Add Prod environment to matrix

### DIFF
--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4
-        with:
-          path: main
       - name: Get AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
@@ -34,9 +32,10 @@ jobs:
         with:
           repository: CMSgov/cdap-private
           ref: 'main'
-          sparse-checkout: ip_sets/ab2d/allowed_ips.txt
+          sparse-checkout: |
+            ip-sets/ab2d/allowed_ips.txt
           sparse-checkout-cone-mode: false
-          path: ips
+          path: ./scripts/ip-sets
           token: ${{ env.OPS_GITHUB_TOKEN }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -44,7 +43,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - name: PWD and LS
-        run: pwd && ls -alh
+        run: pwd && ls -alh; ls scripts; ls scripts/ip-sets
       - name: Run WAF Sync Script
         run: bash waf-ip-set-sync.sh
         env:

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -18,19 +18,30 @@ jobs:
         app: [ab2d]
         env: [dev, test]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - name: Checkout Platform Repository
+        uses: actions/checkout@v4
+      - name: Get AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            OPS_GITHUB_TOKEN=/ci/github/token
+      - name: Checkout Private Repository
+        uses: actions/checkout@v4
         with:
           repository: CMSgov/cdap-private
           ref: 'main'
           sparse-checkout: ip_sets/ab2d/allowed_ips.txt
           sparse-checkout-cone-mode: false
-          token: ${{ env.GITHUB_TOKEN }}
-      - uses: aws-actions/configure-aws-credentials@v4
+          token: ${{ env.OPS_GITHUB_TOKEN }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
-      - run: bash waf-ip-set-sync.sh
+      - name: Run WAF Sync Script
+        run: bash waf-ip-set-sync.sh
         env:
           APP: ${{ matrix.app }}
           ENV: ${{ matrix.env }}

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/cdap-private
-          ref: 'main'
+          ref: 'gfreeman_PLT-508_remove_problematic_cidrs'
           sparse-checkout: |
             ip-sets/ab2d/allowed_ips.txt
           sparse-checkout-cone-mode: false

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -35,7 +35,7 @@ jobs:
           sparse-checkout: |
             ip-sets/ab2d/allowed_ips.txt
           sparse-checkout-cone-mode: false
-          path: ./scripts/ip-sets
+          path: ./scripts/allowed_ips.txt
           token: ${{ env.OPS_GITHUB_TOKEN }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -43,8 +43,9 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - name: PWD and LS
-        run: pwd && ls -alh; ls scripts; ls scripts/ip-sets
+        run: pwd && ls -alh; ls scripts; head -n 2 scripts/allowed_ips.txt
       - name: Run WAF Sync Script
+        working-directory: scripts
         run: bash waf-ip-set-sync.sh
         env:
           APP: ${{ matrix.app }}

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4
+        with:
+          path: main
       - name: Get AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
@@ -34,6 +36,7 @@ jobs:
           ref: 'main'
           sparse-checkout: ip_sets/ab2d/allowed_ips.txt
           sparse-checkout-cone-mode: false
+          path: ips
           token: ${{ env.OPS_GITHUB_TOKEN }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: self-hosted
     defaults:
       run:
+        shell: bash
         working-directory: scripts
     strategy:
       matrix:
@@ -40,6 +41,8 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
+      - name: PWD and LS
+        run: pwd && ls -alh
       - name: Run WAF Sync Script
         run: bash waf-ip-set-sync.sh
         env:

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -35,7 +35,7 @@ jobs:
           sparse-checkout: |
             ip-sets/ab2d/allowed_ips.txt
           sparse-checkout-cone-mode: false
-          path: ./scripts/allowed_ips.txt
+          path: ./scripts
           token: ${{ env.OPS_GITHUB_TOKEN }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         app: [ab2d]
-        env: [dev, test]
+        env: [dev, test, prod]
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -42,8 +42,6 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
-      - name: PWD and LS
-        run: pwd && ls -alh; ls scripts; head -n 2 scripts/temp/ip-sets/ab2d/allowed_ips.txt
       - name: Run WAF Sync Script
         working-directory: scripts
         run: bash waf-ip-set-sync.sh

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -13,7 +13,6 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: scripts
     strategy:
       matrix:
         app: [ab2d]

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted
     defaults:
       run:
-        working-directory: ./scripts
+        working-directory: scripts
     strategy:
       matrix:
         app: [ab2d]

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -35,7 +35,7 @@ jobs:
           sparse-checkout: |
             ip-sets/ab2d/allowed_ips.txt
           sparse-checkout-cone-mode: false
-          path: ./scripts
+          path: ./scripts/temp
           token: ${{ env.OPS_GITHUB_TOKEN }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -43,7 +43,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - name: PWD and LS
-        run: pwd && ls -alh; ls scripts; head -n 2 scripts/allowed_ips.txt
+        run: pwd && ls -alh; ls scripts; head -n 2 scripts/temp/ip-sets/ab2d/allowed_ips.txt
       - name: Run WAF Sync Script
         working-directory: scripts
         run: bash waf-ip-set-sync.sh

--- a/.github/workflows/ab2d-ip-sets-sync.yml
+++ b/.github/workflows/ab2d-ip-sets-sync.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/cdap-private
-          ref: 'gfreeman_PLT-508_remove_problematic_cidrs'
+          ref: 'main'
           sparse-checkout: |
             ip-sets/ab2d/allowed_ips.txt
           sparse-checkout-cone-mode: false

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 echo "Generating IP set"
 
-IPV4_LIST=$(grep -v '^#' allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
+IPV4_LIST=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
 
 echo "Fetching IP set IDs"
 

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 echo "Generating IP set"
 
-IPV4_LIST_RAW=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}' | jq -r .Addresses)
+IPV4_LIST_RAW=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}' | jq -rc .Addresses)
 IPV4_LIST="'$IPV4_LIST_RAW'"
 
 echo "Fetching IP set IDs"

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 echo "Generating IP set"
 
-IPV4_LIST=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}' | jq -r .Addresses)
+IPV4_LIST_RAW=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}' | jq -r .Addresses)
+IPV4_LIST="'$IPV4_LIST_RAW'"
 
 echo "Fetching IP set IDs"
 
@@ -22,5 +23,5 @@ aws wafv2 update-ip-set \
   --scope REGIONAL \
   --id $IPV4_SET_ID \
   --region us-east-1 \
-  --addresses $IPV4_LIST \
+  --addresses "$IPV4_LIST" \
   --lock-token $LOCK_TOKEN

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 
 echo "Generating IP set"
 
-IPV4_LIST_RAW=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}' | jq -rc .Addresses)
-IPV4_LIST="'$IPV4_LIST_RAW'"
+IPV4_LIST=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}' | jq -rc .Addresses)
 
 echo "Fetching IP set IDs"
 

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -11,11 +11,11 @@ echo "Fetching IP set IDs"
 {
   read -r IPV4_SET_ID
   read -r IPV6_SET_ID
-} < <(aws wafv2 list-ip-sets --scope REGIONAL | jq '.IPSets[] | select( .Name | contains("api-customers")) | .Id')
+} < <(aws wafv2 list-ip-sets --scope REGIONAL | jq -r '.IPSets[] | select( .Name | contains("api-customers")) | .Id')
 
 echo "Updating IPv4 set"
 
-LOCK_TOKEN=$(aws wafv2 get-ip-set --name $APP-$ENV-api-customers --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq '.LockToken')
+LOCK_TOKEN=$(aws wafv2 get-ip-set --name $APP-$ENV-api-customers --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq -r '.LockToken')
 
 aws wafv2 update-ip-set \
   --name $APP-$ENV-api-customers \

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -23,4 +23,5 @@ aws wafv2 update-ip-set \
   --id $IPV4_SET_ID \
   --region us-east-1 \
   --addresses $IPV4_LIST \
-  --lock-token $LOCK_TOKEN
+  --lock-token $LOCK_TOKEN \
+  > /dev/null 2>&1

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 echo "Generating IP set"
 
-IPV4_LIST=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
+IPV4_LIST=$(grep -v '^#' temp/ip-sets/ab2d/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}' | jq -r .Addresses)
 
 echo "Fetching IP set IDs"
 

--- a/scripts/waf-ip-set-sync.sh
+++ b/scripts/waf-ip-set-sync.sh
@@ -23,5 +23,5 @@ aws wafv2 update-ip-set \
   --scope REGIONAL \
   --id $IPV4_SET_ID \
   --region us-east-1 \
-  --addresses "$IPV4_LIST" \
+  --addresses $IPV4_LIST \
   --lock-token $LOCK_TOKEN


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-508

## 🛠 Changes

Adds the prod environment to the action's environment matrix.

## ℹ️ Context

When the initial PR for PLT-508 was merged, it only included dev and test for testing purposes, once those pass, we should be able to merge this PR in, but only after the WAF shared service has been rolled out to AB2D production.

## 🧪 Validation

The script should update the WAF IP sets for each environment with the current state of the allowed_ips list in the private repo.
