### PR TITLE
PLT-506: External services WAF IP sync

### DIFF
--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          role-to-assume: arn:aws:iam::${{ matrix.app == 'ab2d' && secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] || secrets.BCDA_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
       - name: Run WAF Sync Script
         working-directory: scripts

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -15,8 +15,8 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        env: [test, dev]
-        app: [ab2d, bcda, dpc]
+        env: [test]
+        app: [bcda]
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/cdap-private
-          ref: 'main'
+          ref: 'jscott/PLT-506'
           sparse-checkout:
             ip-sets/external-services/allowed_ips.txt
           sparse-checkout-cone-mode: false

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         env: [test]
-        app: [ab2d, bcda, dpc]
+        app: [ab2d, bcda] # DPC is not required since external services IP set is shared with BCDA.
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -1,40 +1,50 @@
-name: External Services IP Sets Sync
+name: External Services WAF IP Sets Sync
 
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - 'jscott/PLT-506'
+  workflow_dispatch: # Allow manual trigger
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  waf-ip-sync:
+  external-services-waf-ip-sync:
     runs-on: self-hosted
     defaults:
       run:
-        working-directory: ./scripts
+        shell: bash
     strategy:
       matrix:
         app: [ab2d]
         env: [test]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - name: Checkout Platform Repository
+        uses: actions/checkout@v4
+      - name: Get AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params:
+            OPS_GITHUB_TOKEN=/ci/github/token
+      - name: Checkout Private Repository
+        uses: actions/checkout@v4
         with:
           repository: CMSgov/cdap-private
           ref: 'main'
-          sparse-checkout: ip_sets/external_services/allowed_ips.txt
+          sparse-checkout:
+            ip-sets/external-services/allowed_ips.txt
           sparse-checkout-cone-mode: false
-          token: ${{ env.GITHUB_TOKEN }}
-      - uses: aws-actions/configure-aws-credentials@v4
+          path: ./scripts/temp
+          token: ${{ env.OPS_GITHUB_TOKEN }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
-      - run: bash waf-ip-set-sync.sh
+      - name: Run WAF Sync Script
+        working-directory: scripts
+        run: bash waf-ip-set-sync-external-services.sh
         env:
           APP: ${{ matrix.app }}
           ENV: ${{ matrix.env }}
-          AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -15,8 +15,8 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        app: [ab2d]
-        env: [test]
+        env: [dev, test, prod]
+        app: [ab2d, bcda, dpc]
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -1,0 +1,37 @@
+name: External Services IP Sets Sync
+
+on:
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  waf-ip-sync:
+    runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: ./scripts
+    strategy:
+      matrix:
+        app: [ab2d]
+        env: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: CMSgov/cdap-private
+          ref: 'main'
+          sparse-checkout: ip_sets/external_services/allowed_ips.txt
+          sparse-checkout-cone-mode: false
+          token: ${{ env.GITHUB_TOKEN }}
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets[format('{0}_{1}_ACCOUNT', matrix.app, matrix.env)] }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: bash waf-ip-set-sync.sh
+        env:
+          APP: ${{ matrix.app }}
+          ENV: ${{ matrix.env }}
+          AWS_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -15,8 +15,11 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        env: [test]
-        app: [ab2d, bcda] # DPC is not required since external services IP set is shared with BCDA.
+        app: [ab2d]
+        env: [mgmt, dev, test, sbx, prod]
+        include:
+        - app: bcda
+          env: mgmt
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -1,7 +1,7 @@
 name: External Services WAF IP Sets Sync
 
 on:
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -19,7 +19,7 @@ jobs:
         env: [mgmt, dev, test, sbx, prod]
         include:
         - app: bcda
-          env: prod
+          env: prod # All BCDA and DPC envs share one external-services IPSet.
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: CMSgov/cdap-private
-          ref: 'jscott/PLT-506'
+          ref: 'main'
           sparse-checkout:
             ip-sets/external-services/allowed_ips.txt
           sparse-checkout-cone-mode: false

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         env: [test, dev]
-        app: [ab2d]
+        app: [ab2d, bcda, dpc]
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -1,7 +1,10 @@
 name: External Services IP Sets Sync
 
 on:
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
+  push:
+    branches:
+      - 'jscott/PLT-506'
 
 permissions:
   contents: read

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         app: [ab2d]
-        env: [mgmt, dev, test]
+        env: [mgmt, dev, test, sbx]
         include:
         - app: bcda
-          env: mgmt
+          env: prod
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         env: [test]
-        app: [bcda]
+        app: [ab2d, bcda, dpc]
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -15,8 +15,8 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        env: [dev, test, prod]
-        app: [ab2d, bcda, dpc]
+        env: [test, dev]
+        app: [ab2d]
     steps:
       - name: Checkout Platform Repository
         uses: actions/checkout@v4

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         app: [ab2d]
-        env: [mgmt, dev, test, sbx]
+        env: [mgmt, dev, test, sbx, prod]
         include:
         - app: bcda
           env: prod

--- a/.github/workflows/external-services-ip-sets-sync.yml
+++ b/.github/workflows/external-services-ip-sets-sync.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         app: [ab2d]
-        env: [mgmt, dev, test, sbx, prod]
+        env: [mgmt, dev, test]
         include:
         - app: bcda
           env: mgmt

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -9,10 +9,13 @@ LOCK_TOKEN=$(aws wafv2 get-ip-set --name external-services --scope REGIONAL --id
 
 echo "Beginning 'external services' IPv4 set update."
 
-aws wafv2 update-ip-set \
-  --name external-services \
-  --scope REGIONAL \
-  --id $IPV4_SET_ID \
-  --region us-east-1 \
-  --addresses $IPV4_LIST \
-  --lock-token $LOCK_TOKEN
+# aws wafv2 update-ip-set \
+#   --name external-services \
+#   --scope REGIONAL \
+#   --id $IPV4_SET_ID \
+#   --region us-east-1 \
+#   --addresses $IPV4_LIST \
+#   --lock-token $LOCK_TOKEN
+
+SAMPLE_NAME=$(aws ec2 describe-instances | jq -r '.Reservations[0].Instances[].Tags[] | select( .Key=="Name") | .Value')
+echo "Sample name is ${SAMPLE_NAME}"

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -9,13 +9,10 @@ LOCK_TOKEN=$(aws wafv2 get-ip-set --name external-services --scope REGIONAL --id
 
 echo "Beginning 'external services' IPv4 set update."
 
-# aws wafv2 update-ip-set \
-#   --name external-services \
-#   --scope REGIONAL \
-#   --id $IPV4_SET_ID \
-#   --region us-east-1 \
-#   --addresses $IPV4_LIST \
-#   --lock-token $LOCK_TOKEN
-
-SAMPLE_NAME=$(aws ec2 describe-instances | jq -r '.Reservations[0].Instances[].Tags[] | select( .Key=="Name") | .Value')
-echo "Sample name is ${SAMPLE_NAME}"
+aws wafv2 update-ip-set \
+  --name external-services \
+  --scope REGIONAL \
+  --id $IPV4_SET_ID \
+  --region us-east-1 \
+  --addresses $IPV4_LIST \
+  --lock-token $LOCK_TOKEN

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-IPV4_LIST=$(grep -v '^#' temp/ip-sets/external-services/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
+IPV4_LIST=$(grep -v '^#' temp/ip-sets/external-services/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}' | jq -rc .Addresses)
 IPV4_SET_ID=$(aws wafv2 list-ip-sets --scope REGIONAL --region $AWS_REGION | jq -r '.IPSets[] | select( .Name=="external-services") | .Id')
 
 LOCK_TOKEN=$(aws wafv2 get-ip-set --name external-services --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq -r '.LockToken')

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -15,10 +15,10 @@ echo "App/Env are ${APP} ${ENV}"
 SAMPLE_NAME=$(aws ec2 describe-instances | jq -r '.Reservations[0].Instances[].Tags[] | select( .Key=="Name") | .Value')
 echo "Sample name is ${SAMPLE_NAME}"
 
-# aws wafv2 update-ip-set \
-#   --name external-services \
-#   --scope REGIONAL \
-#   --id $IPV4_SET_ID \
-#   --region us-east-1 \
-#   --addresses $IPV4_LIST \
-#   --lock-token $LOCK_TOKEN
+aws wafv2 update-ip-set \
+  --name external-services \
+  --scope REGIONAL \
+  --id $IPV4_SET_ID \
+  --region us-east-1 \
+  --addresses $IPV4_LIST \
+  --lock-token $LOCK_TOKEN

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -12,6 +12,9 @@ echo "Beginning 'external services' regional IPv4 set update."
 echo "IPV4_SET_ID is ${IPV4_SET_ID}"
 echo "App/Env are ${APP} ${ENV}"
 
+SAMPLE_NAME=$(aws ec2 describe-instances | jq -r '.Reservations[0].Instances[].Tags[] | select( .Key=="Name") | .Value')
+echo "Sample name is ${SAMPLE_NAME}"
+
 # aws wafv2 update-ip-set \
 #   --name external-services \
 #   --scope REGIONAL \

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IPV4_LIST=$(grep -v '^#' allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
+IPV4_SET_ID=$(aws wafv2 list-ip-sets --scope REGIONAL --region $AWS_REGION | jq -r '.IPSets[] | select( .Name=="external-services") | .Id')
+
+LOCK_TOKEN=$(aws wafv2 get-ip-set --name external-services --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq '.LockToken')
+
+echo "Beginning 'external services' regional IPv4 set update."
+
+echo "IPV4_SET_ID is ${IPV4_SET_ID}"
+echo "App/Env are ${APP} ${ENV}"
+
+# aws wafv2 update-ip-set \
+#   --name external-services \
+#   --scope REGIONAL \
+#   --id $IPV4_SET_ID \
+#   --region us-east-1 \
+#   --addresses $IPV4_LIST \
+#   --lock-token $LOCK_TOKEN

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -15,10 +15,10 @@ echo "App/Env are ${APP} ${ENV}"
 SAMPLE_NAME=$(aws ec2 describe-instances | jq -r '.Reservations[0].Instances[].Tags[] | select( .Key=="Name") | .Value')
 echo "Sample name is ${SAMPLE_NAME}"
 
-aws wafv2 update-ip-set \
-  --name external-services \
-  --scope REGIONAL \
-  --id $IPV4_SET_ID \
-  --region us-east-1 \
-  --addresses $IPV4_LIST \
-  --lock-token $LOCK_TOKEN
+# aws wafv2 update-ip-set \
+#   --name external-services \
+#   --scope REGIONAL \
+#   --id $IPV4_SET_ID \
+#   --region us-east-1 \
+#   --addresses $IPV4_LIST \
+#   --lock-token $LOCK_TOKEN

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 IPV4_LIST=$(grep -v '^#' temp/ip-sets/external-services/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
 IPV4_SET_ID=$(aws wafv2 list-ip-sets --scope REGIONAL --region $AWS_REGION | jq -r '.IPSets[] | select( .Name=="external-services") | .Id')
 
-LOCK_TOKEN=$(aws wafv2 get-ip-set --name external-services --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq '.LockToken')
+LOCK_TOKEN=$(aws wafv2 get-ip-set --name external-services --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq -r '.LockToken')
 
 echo "Beginning 'external services' regional IPv4 set update."
 

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -7,18 +7,12 @@ IPV4_SET_ID=$(aws wafv2 list-ip-sets --scope REGIONAL --region $AWS_REGION | jq 
 
 LOCK_TOKEN=$(aws wafv2 get-ip-set --name external-services --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq -r '.LockToken')
 
-echo "Beginning 'external services' regional IPv4 set update."
+echo "Beginning 'external services' IPv4 set update."
 
-echo "IPV4_SET_ID is ${IPV4_SET_ID}"
-echo "App/Env are ${APP} ${ENV}"
-
-SAMPLE_NAME=$(aws ec2 describe-instances | jq -r '.Reservations[0].Instances[].Tags[] | select( .Key=="Name") | .Value')
-echo "Sample name is ${SAMPLE_NAME}"
-
-# aws wafv2 update-ip-set \
-#   --name external-services \
-#   --scope REGIONAL \
-#   --id $IPV4_SET_ID \
-#   --region us-east-1 \
-#   --addresses $IPV4_LIST \
-#   --lock-token $LOCK_TOKEN
+aws wafv2 update-ip-set \
+  --name external-services \
+  --scope REGIONAL \
+  --id $IPV4_SET_ID \
+  --region us-east-1 \
+  --addresses $IPV4_LIST \
+  --lock-token $LOCK_TOKEN

--- a/scripts/waf-ip-set-sync-external-services.sh
+++ b/scripts/waf-ip-set-sync-external-services.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-IPV4_LIST=$(grep -v '^#' allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
+IPV4_LIST=$(grep -v '^#' temp/ip-sets/external-services/allowed_ips.txt | jq -Rs '{Addresses: split("\n") | map(select(length > 0))}')
 IPV4_SET_ID=$(aws wafv2 list-ip-sets --scope REGIONAL --region $AWS_REGION | jq -r '.IPSets[] | select( .Name=="external-services") | .Id')
 
 LOCK_TOKEN=$(aws wafv2 get-ip-set --name external-services --scope REGIONAL --id $IPV4_SET_ID --region us-east-1 | jq '.LockToken')


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-506

## 🛠 Changes

- Added new file external-services-ip-sets-sync.yml runner file
- Added new file waf-ip-set-sync-external-services.sh to run the sync via the AWS CLI.
- Added new file allowed-ips.txt under cdap-private/ip-sets/external-services with IP sets taken from BCDA account.

## ℹ️ Context

These changes are intended to establish a framework for syncing the external-services IPSets from various accounts and environments to a file of CIDR IP ranges in the CDAP private repo. This workflow is currently configured to be manually run, but can easily be reconfigured to run on a schedule or on an update to the CDAP private repo.

## 🧪 Validation

These changes were validated by running a GHA workflow against the AB2D IMPL and BCDA/DPC accounts us-east-1 regions.
