### PR TITLE
PLT-709: Add AB2D Prod to Apply Matrix

### DIFF
--- a/.github/workflows/api-waf-apply.yml
+++ b/.github/workflows/api-waf-apply.yml
@@ -22,15 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [bcda, dpc]
+        app: [ab2d, bcda, dpc]
         env: [dev, test, sbx, prod]
-        include:
-          - app: ab2d
-            env: dev
-          - app: ab2d
-            env: test
-          - app: ab2d
-            env: sbx
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-709

## 🛠 Changes

Adds ab2d to the apply workflow matrix.

## ℹ️ Context

As part of the rollout of the WAF shared service to AB2D prod, we have to add the environment to the terraform apply for the service.

## 🧪 Validation

Once this and https://github.com/CMSgov/ab2d-ops/pull/313 are merged, the new WAF shared service will be associated with the existing load balancer, and handle all IP filtering for the AB2D API.
