### PR TITLE
Remove openssl workaround

### DIFF
--- a/packer/github-actions-runner/install-runner.sh
+++ b/packer/github-actions-runner/install-runner.sh
@@ -42,25 +42,3 @@ echo "Un-tar action runner"
 tar xzf ./$file_name
 echo "Delete tar file"
 rm -rf $file_name
-
-# Workaround for openssl until the IDM team upgrades TLS
-echo "Applying workaround to /etc/pki/tls/openssl.cnf"
-sudo sed -i 's/^openssl_conf = openssl_init/openssl_conf = default_conf/' /etc/pki/tls/openssl.cnf
-
-sudo tee -a /etc/pki/tls/openssl.cnf > /dev/null <<EOL
-
-[default_conf]
-ssl_conf = ssl_section
-
-[ssl_section]
-system_default = system_default_section
-
-[system_default_section]
-providers = provider_sect
-ssl_conf = ssl_module
-MaxProtocol = TLSv1.2
-CipherString = ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:...
-Ciphersuites =
-EOL
-
-echo "Workaround applied successfully."


### PR DESCRIPTION
This is to remove the workaround we needed for openssl 3.0.8

bugfix


## 🛠 Changes

This is to remove the workaround we implemented for openssl 3.0.8

## ℹ️ Context

Amazon released the latest openssl 3.2.2 and it looks like we are hitting errors potentially due to this workaround.

## 🧪 Validation

We will merge and test revert if it does not work.
