### PR TITLE
PLT-930: Pin tfenv release version

### DIFF
--- a/actions/setup-tfenv-terraform/action.yml
+++ b/actions/setup-tfenv-terraform/action.yml
@@ -13,7 +13,7 @@ runs:
           echo "tfenv already installed, skipping"
         else
           TMPDIR=$(mktemp -d)
-          git clone --depth=1 https://github.com/tfutils/tfenv.git $TMPDIR
+          git clone --depth=1 --branch v3.0.0 https://github.com/tfutils/tfenv.git $TMPDIR
           mv $TMPDIR ~/.tfenv
           echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
         fi


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-930

## 🛠 Changes

Pins a specific release of the tfenv project for use in Github actions.

## ℹ️ Context

We're pinning the version of this utility until we can move to a higher confidence installation method. See comments in ticket.

## 🧪 Validation

We're already using this version of [tfenv](https://github.com/tfutils/tfenv), it will just prevent automatic updates from happening in the future.
