### PR TITLE
Unenforce fips for idm access

### DIFF
--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -48,7 +48,9 @@ build {
   }
 
   provisioner "shell" {
-    remote_folder = "/home/ec2-user/"
+    remote_folder     = "/home/ec2-user/"
+    expect_disconnect = true
+    pause_before      = "30s" # Gives EC2 a little time to fully boot again
     inline = [
       "chmod +x /home/ec2-user/install-runner.sh",
       "/home/ec2-user/install-runner.sh"

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -48,7 +48,7 @@ build {
   }
 
   provisioner "shell" {
-    remote_folder     = "/home/ec2-user/"
+    remote_folder = "/home/ec2-user/"
     inline = [
       "chmod +x /home/ec2-user/install-runner.sh",
       "/home/ec2-user/install-runner.sh"

--- a/packer/github-actions-runner/build.pkr.hcl
+++ b/packer/github-actions-runner/build.pkr.hcl
@@ -49,8 +49,6 @@ build {
 
   provisioner "shell" {
     remote_folder     = "/home/ec2-user/"
-    expect_disconnect = true
-    pause_before      = "30s" # Gives EC2 a little time to fully boot again
     inline = [
       "chmod +x /home/ec2-user/install-runner.sh",
       "/home/ec2-user/install-runner.sh"

--- a/packer/github-actions-runner/install-runner.sh
+++ b/packer/github-actions-runner/install-runner.sh
@@ -19,6 +19,10 @@ echo "Setting up GH Actions runner tool cache"
 sudo mkdir -p /opt/hostedtoolcache
 sudo chown -R ec2-user:ec2-user /opt/hostedtoolcache
 
+# Workaround for idm ems issue
+
+sudo update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+
 echo "Creating actions-runner directory for the GH Action installation"
 sudo mkdir -p /opt/actions-runner
 sudo chown -R ec2-user:ec2-user /opt/actions-runner

--- a/packer/github-actions-runner/install-runner.sh
+++ b/packer/github-actions-runner/install-runner.sh
@@ -22,7 +22,6 @@ sudo chown -R ec2-user:ec2-user /opt/hostedtoolcache
 # The IDM server that AB2D needs to access doesn't support TLSv1.2 with EMS
 # See https://www.redhat.com/en/blog/tls-extended-master-secret-and-fips-rhel
 sudo update-crypto-policies --set FIPS:NO-ENFORCE-EMS
-sudo reboot
 
 echo "Creating actions-runner directory for the GH Action installation"
 sudo mkdir -p /opt/actions-runner

--- a/packer/github-actions-runner/install-runner.sh
+++ b/packer/github-actions-runner/install-runner.sh
@@ -22,6 +22,7 @@ sudo chown -R ec2-user:ec2-user /opt/hostedtoolcache
 # The IDM server that AB2D needs to access doesn't support TLSv1.2 with EMS
 # See https://www.redhat.com/en/blog/tls-extended-master-secret-and-fips-rhel
 sudo update-crypto-policies --set FIPS:NO-ENFORCE-EMS
+sudo reboot
 
 echo "Creating actions-runner directory for the GH Action installation"
 sudo mkdir -p /opt/actions-runner

--- a/packer/github-actions-runner/install-runner.sh
+++ b/packer/github-actions-runner/install-runner.sh
@@ -19,8 +19,8 @@ echo "Setting up GH Actions runner tool cache"
 sudo mkdir -p /opt/hostedtoolcache
 sudo chown -R ec2-user:ec2-user /opt/hostedtoolcache
 
-# Workaround for idm ems issue
-
+# The IDM server that AB2D needs to access doesn't support TLSv1.2 with EMS
+# See https://www.redhat.com/en/blog/tls-extended-master-secret-and-fips-rhel
 sudo update-crypto-policies --set FIPS:NO-ENFORCE-EMS
 
 echo "Creating actions-runner directory for the GH Action installation"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1007

## 🛠 Changes

Changing fips mode to not enforce

## ℹ️ Context

https://cmsgov.slack.com/archives/CNVRZ73NF/p1744121296051429?thread_ts=1744054808.021109&cid=CNVRZ73NF

We are having issues with fips mode being enforced and idm not allowing access from our runners because of this.

Security review from @SJWalter11 required due to FIPS configuration change.

## Security

IDM by default doesn't require fips with TLS 1.2. Amazon Linux 2023 uses openssl 3.x.x by default and with this comes with TLS 1.3 and fips enabled. Without building openssl on our own which would increase our build times significantly we cannot get around this issue without our workaround to disable it in the AMI build.

## 🧪 Validation
This has been run and works now
https://github.com/CMSgov/ab2d/actions/runs/14344192229/job/40210438843
