### PR TITLE
[PLT-890] resource type change per hashi guidance

### DIFF
--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -90,6 +90,7 @@ resource "aws_vpc_security_group_ingress_rule" "function_access" {
   to_port                      = 5432
   ip_protocol                  = "tcp"
   description                  = "opt-out-export function access"
+
   security_group_id            = data.aws_security_group.db.id
   referenced_security_group_id = module.opt_out_export_function.security_group_id
 }

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -90,6 +90,7 @@ resource "aws_vpc_security_group_ingress_rule" "function_access" {
   to_port     = 5432
   ip_protocol = "tcp"
   description = "opt-out-export function access"
+  cidr_ipv4   = "0.0.0.0/0"
 
   security_group_id = data.aws_security_group.db.id
 }

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -91,5 +91,5 @@ resource "aws_vpc_security_group_ingress_rule" "function_access" {
   ip_protocol = "tcp"
   description = "opt-out-export function access"
 
-  security_group_id        = data.aws_security_group.db.id
+  security_group_id = data.aws_security_group.db.id
 }

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -90,7 +90,6 @@ resource "aws_vpc_security_group_ingress_rule" "function_access" {
   to_port     = 5432
   ip_protocol = "tcp"
   description = "opt-out-export function access"
-
   security_group_id            = data.aws_security_group.db.id
   referenced_security_group_id = module.opt_out_export_function.security_group_id
 }

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -86,10 +86,10 @@ data "aws_security_group" "db" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "function_access" {
-  from_port                    = 5432
-  to_port                      = 5432
-  ip_protocol                  = "tcp"
-  description                  = "opt-out-export function access"
+  from_port   = 5432
+  to_port     = 5432
+  ip_protocol = "tcp"
+  description = "opt-out-export function access"
 
   security_group_id            = data.aws_security_group.db.id
   referenced_security_group_id = module.opt_out_export_function.security_group_id

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -90,7 +90,7 @@ resource "aws_vpc_security_group_ingress_rule" "function_access" {
   to_port     = 5432
   ip_protocol = "tcp"
   description = "opt-out-export function access"
-  cidr_ipv4   = "0.0.0.0/0"
 
-  security_group_id = data.aws_security_group.db.id
+  security_group_id            = data.aws_security_group.db.id
+  referenced_security_group_id = module.opt_out_export_function.security_group_id
 }

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -86,10 +86,10 @@ data "aws_security_group" "db" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "function_access" {
-  from_port   = 5432
-  to_port     = 5432
-  ip_protocol = "tcp"
-  description = "opt-out-export function access"
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  description                  = "opt-out-export function access"
   security_group_id            = data.aws_security_group.db.id
   referenced_security_group_id = module.opt_out_export_function.security_group_id
 }

--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -85,13 +85,11 @@ data "aws_security_group" "db" {
   name = local.db_sg_name[var.app]
 }
 
-resource "aws_security_group_rule" "function_access" {
-  type        = "ingress"
+resource "aws_vpc_security_group_ingress_rule" "function_access" {
   from_port   = 5432
   to_port     = 5432
-  protocol    = "tcp"
+  ip_protocol = "tcp"
   description = "opt-out-export function access"
 
   security_group_id        = data.aws_security_group.db.id
-  source_security_group_id = module.opt_out_export_function.security_group_id
 }


### PR DESCRIPTION
## 🎫 Ticket

[https:/https://jira.cms.gov/browse/PLT-890
/jira.cms.gov/browse/PLT-890](https://jira.cms.gov/browse/PLT-890)

## 🛠 Changes

Added new security group rule type per guidance from Hashicorp.  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule

## ℹ️ Context

Changes are to fix workflow failures for dpc-dev

## 🧪 Validation

Green workflow:  opt-out-export apply terraform  for DPC-DEV
