### PR TITLE
Revert change to fix tfenv install

### DIFF
--- a/actions/setup-tfenv-terraform/action.yml
+++ b/actions/setup-tfenv-terraform/action.yml
@@ -14,7 +14,8 @@ runs:
         else
           TMPDIR=$(mktemp -d)
           git clone --depth=1 --branch v3.0.0 https://github.com/tfutils/tfenv.git $TMPDIR
-          echo "$TMPDIR/bin" >> "$GITHUB_PATH"
+          mv $TMPDIR ~/.tfenv
+          echo "PATH=$HOME/.tfenv/bin:$PATH" >> "$GITHUB_ENV"
         fi
       shell: bash
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-891

## 🛠 Changes

Reverts changes made in a previous PR that broke the tfenv install step

## ℹ️ Context

We started seeing failures from some teams after we made a change that broke permissions for the tfenv install https://github.com/CMSgov/ab2d-bcda-dpc-platform/pull/214

## 🧪 Validation

Teams should see the tfenv step function as expected after this is merged
