### PR TITLE
PLT-1040: Add bucket SSM Parameter back to Greenfield Environments

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -13,6 +13,13 @@ resource "aws_s3_bucket" "this" {
   force_destroy = true
 }
 
+resource "aws_ssm_parameter" "bucket" {
+  count = var.ssm_parameter != null ? 1 : 0
+  name  = var.ssm_parameter
+  value = aws_s3_bucket.this.id
+  type  = "String"
+}
+
 resource "aws_s3_bucket_versioning" "this" {
   bucket = aws_s3_bucket.this.id
 

--- a/terraform/modules/bucket/variables.tf
+++ b/terraform/modules/bucket/variables.tf
@@ -14,3 +14,9 @@ variable "legacy" {
   type        = bool
   default     = true
 }
+
+variable "ssm_parameter" {
+  description = "SSM Parameter path for bucket output"
+  type        = string
+  default     = null
+}

--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -146,7 +146,8 @@ module "zip_bucket" {
     "arn:aws:iam::${data.aws_ssm_parameter.sbx_account[0].value}:role/delegatedadmin/developer/${var.app}-sbx-github-actions",
   ] : []
 
-  legacy = var.legacy
+  legacy        = var.legacy
+  ssm_parameter = var.legacy ? null : "/${var.app}/${var.env}/${var.name}-bucket"
 }
 
 resource "aws_s3_object" "empty_function_zip" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1040

## 🛠 Changes

This adds back an optional parameter that references the name of the bucket passed in through the `function` module. 

## ℹ️ Context

We removed the SSM Parameter for the bucket since it was creating parameters in every environment on legacy as well as greenfield. This removal makes greenfield development a bit harder as we cannot interpolate the bucket name by by App and Environment during deployment.

## 🧪 Validation

This should allow DPC to continue greenfield development and deployment
