### PR TITLE
PLT-1008: Support API RDS in Greenfield

### DIFF
--- a/terraform/services/api-rds/data.tf
+++ b/terraform/services/api-rds/data.tf
@@ -130,6 +130,12 @@ data "aws_security_group" "github_runner" {
   }
 }
 
+data "aws_ssm_parameter" "cdap_mgmt_vpc_cidr" {
+  count = var.legacy ? 0 : 1
+
+  name = "/cdap/mgmt-vpc/cidr"
+}
+
 data "aws_ssm_parameter" "quicksight_cidr_blocks" {
   count = var.app != "ab2d" ? 1 : 0
   name  = "/${var.app}/${local.stdenv}/quicksight-rds/cidr-blocks"

--- a/terraform/services/api-rds/data.tf
+++ b/terraform/services/api-rds/data.tf
@@ -6,8 +6,9 @@ locals {
   )
   secret_date = "2020-01-02-09-15-01"
   gdit_security_group_names = var.app == "bcda" ? [
-    "${var.app}-${local.stdenv}-vpn-private",
-    "${var.app}-${local.stdenv}-vpn-public",
+    #FIXME: Temporarily disabled in greenfield, potentially permanently
+    var.legacy ? "${var.app}-${local.stdenv}-vpn-private" : null,
+    var.legacy ? "${var.app}-${local.stdenv}-vpn-public" : null,
     "${var.app}-${local.stdenv}-remote-management",
     "${var.app}-${local.stdenv}-enterprise-tools",
     "${var.app}-${local.stdenv}-allow-zscaler-private"
@@ -81,7 +82,8 @@ data "aws_subnets" "db" {
 
 # Fetch the security group for ab2d
 data "aws_security_group" "controller_security_group_id" {
-  count = var.app == "ab2d" ? 1 : 0
+  #FIXME: Temporarily disabled in greenfield
+  count = var.legacy && var.app == "ab2d" ? 1 : 0
 
   tags = {
     Name = "${local.db_name}-deployment-controller-sg"
@@ -89,7 +91,10 @@ data "aws_security_group" "controller_security_group_id" {
 }
 
 data "aws_kms_alias" "main_kms" {
-  count = var.app == "ab2d" || var.app == "dpc" ? 1 : 0 # Only query the KMS alias for ab2d or dpc
+  #FIXME: Temporarily disabled in greenfield
+  count = var.legacy && (var.app == "ab2d" || var.app == "dpc") ? 1 : 0 # Only query the KMS alias for ab2d or dpc
+  name  = var.app == "ab2d" ? "alias/${local.db_name}-main-kms" : "alias/dpc-${local.stdenv}-master-key"
+}
 
   #TODO: This will have to change for Greenfield
   name = var.app == "ab2d" ? "alias/${local.db_name}-main-kms" : "alias/dpc-${local.stdenv}-master-key"
@@ -97,7 +102,8 @@ data "aws_kms_alias" "main_kms" {
 
 
 data "aws_security_group" "app_sg" {
-  count = var.app == "bcda" ? 1 : 0
+  #FIXME: Temporarily disabled in greenfield
+  count = var.legacy && var.app == "bcda" ? 1 : 0
   filter {
     name   = "tag:Name"
     values = ["${var.app}-api-${local.stdenv}"] # This will look for the bcda api app security group named based on the environment
@@ -105,7 +111,8 @@ data "aws_security_group" "app_sg" {
 }
 
 data "aws_security_group" "worker_sg" {
-  count = var.app == "bcda" ? 1 : 0
+  #FIXME: Temporarily disabled in greenfield
+  count = var.legacy && var.app == "bcda" ? 1 : 0
   filter {
     name   = "tag:Name"
     values = ["${var.app}-worker-${local.stdenv}"] #This looks for the bcda worker security group named based on the environment
@@ -113,7 +120,7 @@ data "aws_security_group" "worker_sg" {
 }
 
 data "aws_security_group" "gdit" {
-  for_each = toset(local.gdit_security_group_names)
+  for_each = toset([for name in local.gdit_security_group_names : name if name != null])
 
   filter {
     name   = "tag:Name" # Filter by 'Name' tag
@@ -122,7 +129,8 @@ data "aws_security_group" "gdit" {
 }
 
 data "aws_security_group" "github_runner" {
-  count = var.app == "bcda" ? 1 : 0
+  #FIXME: Temporarily disabled in greenfield
+  count = var.legacy && var.app == "bcda" ? 1 : 0
 
   filter {
     name   = "tag:Name"
@@ -156,6 +164,6 @@ data "aws_security_groups" "dpc_additional_sg" {
 }
 
 data "aws_iam_role" "rds_monitoring" {
-  count = var.app == "dpc" ? 1 : 0
+  count = var.legacy && var.app == "dpc" ? 1 : 0
   name  = "rds-monitoring-role"
 }

--- a/terraform/services/api-rds/data.tf
+++ b/terraform/services/api-rds/data.tf
@@ -96,8 +96,8 @@ data "aws_kms_alias" "main_kms" {
   name  = var.app == "ab2d" ? "alias/${local.db_name}-main-kms" : "alias/dpc-${local.stdenv}-master-key"
 }
 
-  #TODO: This will have to change for Greenfield
-  name = var.app == "ab2d" ? "alias/${local.db_name}-main-kms" : "alias/dpc-${local.stdenv}-master-key"
+data "aws_kms_alias" "default_rds" {
+  name = "alias/aws/rds"
 }
 
 

--- a/terraform/services/api-rds/data.tf
+++ b/terraform/services/api-rds/data.tf
@@ -17,6 +17,7 @@ locals {
     "${var.app}-${local.stdenv}-enterprise-tools",
     "${var.app}-${local.stdenv}-allow-zscaler-private"
   ] : []
+  #NOTE: `db_username` and `db_password` are path/names to secrets for secrets manager datasource
   db_username = {
     ab2d = "${var.app}/${local.db_name}/module/db/database_user/${local.secret_date}"
     bcda = "${var.app}/${local.stdenv}/db/username"

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -268,7 +268,8 @@ resource "aws_db_instance" "api" {
     ignore_changes = [
       username,
       password,
-      engine_version
+      engine_version,
+      kms_key_id #FIXME temporary allowance for legacy environments 😬
     ]
   }
 }

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -215,7 +215,7 @@ resource "aws_db_instance" "api" {
     "upgrade",
   ]
   skip_final_snapshot                   = true
-  snapshot_identifier                   = var.app == "dpc" ? var.snapshot : null # default will be null
+  snapshot_identifier                   = var.snapshot
   final_snapshot_identifier             = var.app == "dpc" ? "dpc-${var.env}-${var.name}-20190829-final" : null
   auto_minor_version_upgrade            = var.app == "dpc" ? true : null
   allow_major_version_upgrade           = var.app == "bcda" ? true : null

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -287,6 +287,11 @@ resource "aws_route53_zone" "local_zone" {
   count = var.app == "dpc" ? 1 : 0
 
   name = "${var.app}-${local.stdenv}.local"
+
+  vpc {
+    vpc_id = module.vpc.id
+  }
+
   tags = merge(
     data.aws_default_tags.data_tags.tags,
     var.app == "dpc" ? local.dpc_specific_tags : {}

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -272,6 +272,7 @@ resource "aws_db_instance" "api" {
     ]
   }
 }
+
 /* DB - Route53 */
 resource "aws_route53_record" "rds" {
   count   = var.app == "bcda" || var.app == "dpc" ? 1 : 0
@@ -281,7 +282,6 @@ resource "aws_route53_record" "rds" {
   ttl     = "300"
   records = [aws_db_instance.api.address]
 }
-
 
 resource "aws_route53_zone" "local_zone" {
   count = var.app == "dpc" ? 1 : 0

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -203,7 +203,6 @@ resource "aws_db_parameter_group" "v16_parameter_group" {
 }
 
 # Create database instance
-
 resource "aws_db_instance" "api" {
   allocated_storage   = local.allocated_storage
   engine              = "postgres"

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -235,7 +235,7 @@ resource "aws_db_instance" "api" {
   performance_insights_retention_period = var.app == "dpc" ? 7 : null
   backup_window                         = var.app == "dpc" || var.app == "bcda" ? "05:00-05:30" : null #1 am EST
   copy_tags_to_snapshot                 = var.app == "bcda" || var.app == "dpc" ? true : false
-  kms_key_id                            = var.app == "ab2d" || var.app == "dpc" ? data.aws_kms_alias.main_kms[0].target_key_arn : null
+  kms_key_id                            = var.legacy && (var.app == "ab2d" || var.app == "dpc") ? data.aws_kms_alias.main_kms[0].target_key_arn : data.aws_kms_alias.default_rds.target_key_arn
   multi_az                              = var.app == "dpc" ? (local.stdenv == "prod" || local.stdenv == "prod-sbx") : (var.env == "prod" || var.app == "bcda" ? true : false)
   vpc_security_group_ids = (var.app == "bcda" || var.app == "dpc") ? concat(
   [aws_security_group.sg_database.id], local.gdit_security_group_ids) : [aws_security_group.sg_database.id]

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -86,7 +86,7 @@ resource "aws_vpc_security_group_egress_rule" "egress_all" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "db_access_from_jenkins_agent" {
-  count                        = var.app == "bcda" || var.app == "ab2d" ? 1 : 0
+  count                        = var.legacy && (var.app == "bcda" || var.app == "ab2d") ? 1 : 0
   description                  = "Jenkins Agent Access"
   from_port                    = "5432"
   to_port                      = "5432"

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -111,7 +111,7 @@ resource "aws_vpc_security_group_ingress_rule" "db_access_from_mgmt" {
   from_port         = 5432
   to_port           = 5432
   ip_protocol       = "tcp"
-  cidr_ipv4         = var.mgmt_vpc_cidr
+  cidr_ipv4         = var.legacy ? var.mgmt_vpc_cidr : data.aws_ssm_parameter.cdap_mgmt_vpc_cidr[0].value
   security_group_id = aws_security_group.sg_database.id
 }
 

--- a/terraform/services/api-rds/variables.tf
+++ b/terraform/services/api-rds/variables.tf
@@ -21,6 +21,7 @@ variable "env" {
 variable "jenkins_security_group_id" {
   description = "Stores the security group managing Jenkins Agent for AB2D including account number for AB2D Management"
   type        = string
+  default     = null
 }
 
 variable "mgmt_vpc_cidr" {

--- a/terraform/services/api-rds/variables.tf
+++ b/terraform/services/api-rds/variables.tf
@@ -26,6 +26,7 @@ variable "jenkins_security_group_id" {
 variable "mgmt_vpc_cidr" {
   description = "CIDR for the Management VPC"
   type        = string
+  default     = null
 }
 
 variable "name" {

--- a/terraform/services/service-security-groups/main.tf
+++ b/terraform/services/service-security-groups/main.tf
@@ -23,18 +23,27 @@ resource "aws_security_group" "zscaler_public" {
   name        = "${var.app}-${var.env}-allow-zscaler-public"
   description = "Allow public zscaler traffic"
   vpc_id      = module.vpc.id
+  tags = {
+    Name = "${var.app}-${var.env}-allow-zscaler-public"
+  }
 }
 
 resource "aws_security_group" "zscaler_private" {
   name        = "${var.app}-${var.env}-allow-zscaler-private"
   description = "Allow internet zscaler traffic private"
   vpc_id      = module.vpc.id
+  tags = {
+    Name = "${var.app}-${var.env}-allow-zscaler-private"
+  }
 }
 
 resource "aws_security_group" "internet" {
   name        = "${var.app}-${var.env}-internet"
   description = "Allow access to the internet"
   vpc_id      = module.vpc.id
+  tags = {
+    Name = "${var.app}-${var.env}-internet"
+  }
 }
 
 resource "aws_vpc_security_group_egress_rule" "internet_http" {

--- a/terraform/services/service-security-groups/main.tf
+++ b/terraform/services/service-security-groups/main.tf
@@ -2,6 +2,7 @@ module "vpc" {
   source = "../../modules/vpc"
   app    = var.app
   env    = var.env
+  legacy = var.legacy
 }
 
 resource "aws_security_group" "zscaler_public" {

--- a/terraform/services/service-security-groups/main.tf
+++ b/terraform/services/service-security-groups/main.tf
@@ -1,3 +1,17 @@
+locals {
+  stdenv = (
+    var.app == "bcda" ? (var.env == "sbx" ? "opensbx" : var.env) :
+    var.app == "dpc" ? (var.env == "sbx" ? "prod-sbx" : var.env) :
+    var.env
+  )
+}
+
+data "aws_ssm_parameter" "cdap_mgmt_vpc_cidr" {
+  count = var.legacy ? 0 : 1
+
+  name = "/cdap/mgmt-vpc/cidr"
+}
+
 module "vpc" {
   source = "../../modules/vpc"
   app    = var.app
@@ -41,4 +55,62 @@ resource "aws_vpc_security_group_egress_rule" "internet_https" {
   from_port   = 443
   ip_protocol = "tcp"
   to_port     = 443
+}
+
+resource "aws_security_group" "remote_management" {
+  count       = var.legacy ? 0 : 1
+  name        = "${var.app}-${local.stdenv}-remote-management"
+  description = "Security group for remote management"
+  vpc_id      = module.vpc.id
+  tags = {
+    Name = "${var.app}-${local.stdenv}-remote-management"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "remote_management_allow_all" {
+  count             = var.legacy ? 0 : 1
+  security_group_id = aws_security_group.remote_management[0].id
+  description       = "Allow all traffic to CDAP management VPC"
+  cidr_ipv4         = !var.legacy ? data.aws_ssm_parameter.cdap_mgmt_vpc_cidr[0].value : null
+  from_port         = 5432
+  to_port           = 5432
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "remote_management_egress" {
+  count             = var.legacy ? 0 : 1
+  security_group_id = aws_security_group.remote_management[0].id
+
+  description = "Allow all egress"
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = -1
+}
+
+resource "aws_security_group" "enterprise_tools" {
+  count       = var.legacy ? 0 : 1
+  name        = "${var.app}-${local.stdenv}-enterprise-tools"
+  description = "Security group for enterprise tools"
+  vpc_id      = module.vpc.id
+  tags = {
+    Name = "${var.app}-${local.stdenv}-enterprise-tools"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "enterprise_tools_allow_all" {
+  count             = var.legacy ? 0 : 1
+  security_group_id = aws_security_group.enterprise_tools[0].id
+  description       = "Allow all traffic to CDAP management VPC"
+  cidr_ipv4         = !var.legacy ? data.aws_ssm_parameter.cdap_mgmt_vpc_cidr[0].value : null
+  from_port         = 5432
+  to_port           = 5432
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "enterprise_tools_egress" {
+  count             = var.legacy ? 0 : 1
+  security_group_id = aws_security_group.enterprise_tools[0].id
+
+  description = "Allow all egress"
+  cidr_ipv4   = "0.0.0.0/0"
+  ip_protocol = -1
 }

--- a/terraform/services/service-security-groups/variables.tf
+++ b/terraform/services/service-security-groups/variables.tf
@@ -16,3 +16,8 @@ variable "env" {
   }
 }
 
+variable "legacy" {
+  description = "Is this deployment in the greenfield environment (false)?"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1008

## 🛠 Changes

In short, this PR brings about necessary changes to run in the greenfield environments along with some bug fixes that weren't revealed until now:
- fix the AWS secret lookup resolution; document
- make use of default aws/rds KMS keys
- fix issues where bcda terraform and _this_ module both attempt to create local hosted zones
- introduce a number of `rds-api` module dependency security groups to `service-security-groups` for greenfield
- make required variables in `rds-api` optional using lookups (mgmt cidr) or ignoring them (jenkins subnets)
- annotate and disable certain resources in greenfield to allow this module to apply


## ℹ️ Context
This is the first time we've had the opportunity to use these modules to instantiate environments.
Naturally, there were a number of key assumptions that made it into the solution.
Where possible, we've gone forward with temporarily disabling certain resource dependencies that have not yet been met in the greenfield environment fully understanding that some of these dependencies will never be met.

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

CI should run with results that have few, modest changes to the resources. Namely, we're looking for tags on legacy resources to be updated, and little else.