### PR TITLE
PLT-1060 security group sync workflow

### DIFF
--- a/.github/workflows/sync-external-services-ip-sets.yml
+++ b/.github/workflows/sync-external-services-ip-sets.yml
@@ -48,6 +48,3 @@ jobs:
         run: |
           scripts/sync-ip-set --name=external-services --scope=REGIONAL cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt
           scripts/sync-ip-set --name=external-services --scope=CLOUDFRONT cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt
-        env:
-          ENV: ${{ matrix.env }}
-          CIDR_FILE: ${{ inputs.cidr_file }}

--- a/.github/workflows/sync-security-groups.yml
+++ b/.github/workflows/sync-security-groups.yml
@@ -1,6 +1,7 @@
 name: sync-security-groups
 
 on:
+  push:
   workflow_dispatch: # Allow manual trigger
     inputs:
       private_branch:

--- a/.github/workflows/sync-security-groups.yml
+++ b/.github/workflows/sync-security-groups.yml
@@ -1,7 +1,6 @@
 name: sync-security-groups
 
 on:
-  push:
   workflow_dispatch: # Allow manual trigger
     inputs:
       private_branch:

--- a/.github/workflows/sync-security-groups.yml
+++ b/.github/workflows/sync-security-groups.yml
@@ -1,0 +1,50 @@
+name: sync-security-groups
+
+on:
+  workflow_dispatch: # Allow manual trigger
+    inputs:
+      private_branch:
+        description: Which branch of the private repo to check out
+        required: false
+        type: string
+        default: main
+
+permissions:
+  contents: read
+  id-token: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ip-set-sync:
+    runs-on: codebuild-cdap-${{github.run_id}}-${{github.run_attempt}}
+    strategy:
+      fail-fast: false
+      matrix: # Only run once per account
+        app: [bcda]
+        env: [test, prod]
+    steps:
+      - name: Get AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            CI_GITHUB_TOKEN=/ci/github/token
+      - name: Check out private repo
+        uses: actions/checkout@v4
+        with:
+          repository: CMSgov/cdap-private
+          token: ${{ env.CI_GITHUB_TOKEN }}
+          ref: ${{ inputs.private_branch }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ contains(fromJSON('["dev", "test"]'), matrix.env) && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Run script to sync security groups
+        run: |
+          scripts/sync-security-groups zscaler-private
+          scripts/sync-security-groups zscaler-public


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1060

## 🛠 Changes

Added sync-security-groups workflow. Also made a small fix on sync-external-services-ip-sets.

## ℹ️ Context

This workflow should allow us to sync rules on security groups from CIDRs in cdap-private. Currently syncs zscaler-private and zscaler-public.

## 🧪 Validation

Successful workflow runs at https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/15073061359 and https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/15073825193. Security groups checked and all rules are present.