### PR TITLE
[PLT-1058] added https policy for logging bucket

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -103,3 +103,34 @@ resource "aws_s3_bucket_logging" "this" {
   target_bucket = data.aws_s3_bucket.bucket_access_logs.id
   target_prefix = "${var.name}/"
 }
+
+resource "aws_s3_bucket_policy" "denyhttp" {
+  bucket = aws_s3_bucket.this.bucket
+  policy = data.aws_iam_policy_document.https_only_policy.json
+}
+
+data "aws_iam_policy_document" "https_only_policy" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    effect = "Deny"
+
+    actions = [
+      "s3:*"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    resources = [
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+  }
+}
+


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1058

## 🛠 Changes

Added an https only bucket policy to logging buckets

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

To secure transport to logging bucket

## 🧪 Validation
From Terraform Plan:
Terraform will perform the following actions:

  module.tfstate_bucket.aws_s3_bucket_policy.denyhttp will be created


Plan: 1 to add, 0 to change, 0 to destroy.
