### PR TITLE
PLT-1033: Introduce a platform child module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 terraform.tfstate*
 terraform.tfvars
 .terraform*
+!.terraform-docs.yml

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,51 @@
+formatter: markdown table
+sections:
+  show:
+    - requirements
+    - inputs
+    - resources
+    - outputs
+    - data-sources
+    - modules
+
+# this `content` string is implemented as a golang template https://pkg.go.dev/text/template
+# updates here correspond to `{{ .Content }}` in `output.template` setting below
+content: |-
+    {{ $warning := `<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+         'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+         Manually updating sections between TF_DOCS tags may be overwritten.
+         See https://terraform-docs.io/user-guide/configuration/ for more information.
+    -->`}}
+
+    {{- $warning }}
+    {{ .Requirements }}
+
+    {{ $warning }}
+    {{ .Inputs }}
+
+    {{ $warning }}
+    {{ .Modules }}
+
+    {{ $warning }}
+    {{ .Resources }}
+
+    {{ $warning }}
+    {{ .Outputs }}
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  indent: 2
+  default: true
+  required: true
+  type: true

--- a/terraform/modules/platform/README.md
+++ b/terraform/modules/platform/README.md
@@ -1,6 +1,32 @@
 # Platform Child Module
 
-This is a simple child module comprised of data sources, outputs, and some modest logic to encourage adoption of emerging, platform-wide standards.
+This simple [child module](https://developer.hashicorp.com/terraform/language/modules#child-modules) comprises data sources, outputs, and some modest logic to encourage adoption of DASG's emerging, _platform_-wide standards for use in CDAP-customer terraform modules.
+The resources that are referenced by terraform data source in this module are managed by the CMS Hybrid Cloud team and/or the CDAP team.
+
+## Example Usage
+
+```hcl
+## AB2D API Module Usage Example
+module "platform" {
+  # Ensure `ref` in the following line is pinned to something static
+  # e.g. a known branch, commit hash, or tag from **this repository**
+  source = "git::https://github.com/CMSgov/ab2d-bcda-dpc-platform.git//terraform/modules/platform?ref=plt-1033"
+
+  app         = "ab2d"
+  env         = var.env
+  root_module = "https://github.com/CMSgov/ab2d-ops/tree/main/terraform/services/api"
+  service     = "api"
+}
+
+## Configure the aws provider with the default tag standards sourced from the `platform` child module
+provider "aws" {
+  region = "us-east-1"
+
+  default_tags {
+    tags = module.platform.default_tags
+  }
+}
+```
 
 <!-- BEGIN_TF_DOCS -->
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
@@ -80,14 +106,14 @@ No modules.
 | <a name="output_is_ephemeral_env"></a> [is\_ephemeral\_env](#output\_is\_ephemeral\_env) | Returns true when environment is \_ephemeral\_, false when \_established\_ |
 | <a name="output_kion_roles"></a> [kion\_roles](#output\_kion\_roles) | Map of common kion/cloudtamer [aws\_iam\_role data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `name`. |
 | <a name="output_logging_bucket"></a> [logging\_bucket](#output\_logging\_bucket) | The designated access log bucket [aws\_s3\_bucket data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket#attribute-reference) for the current environment |
-| <a name="output_nat_gateways"></a> [nat\_gateways](#output\_nat\_gateways) | Map of current VPC's **available** [aws\_nat\_gateway data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `id`. |
+| <a name="output_nat_gateways"></a> [nat\_gateways](#output\_nat\_gateways) | Map of current VPC **available** [aws\_nat\_gateway data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `id`. |
 | <a name="output_parent_env"></a> [parent\_env](#output\_parent\_env) | The solution's source environment. For established environments this is equal to the environment's name |
 | <a name="output_platform_cidr"></a> [platform\_cidr](#output\_platform\_cidr) | The CIDR-range for the CDAP-managed VPC for CI and other administrative functions. |
-| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | Map of current VPCs **private** [aws\_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `subnet_id` |
-| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | Map of current VPCs **public** [aws\_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `id` |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | Map of current VPC **private** [aws\_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `subnet_id` |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | Map of current VPC **public** [aws\_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `id` |
 | <a name="output_region_name"></a> [region\_name](#output\_region\_name) | The region name associated with the current caller identity |
 | <a name="output_sdlc_env"></a> [sdlc\_env](#output\_sdlc\_env) | The SDLC (production vs non-production) environment. |
 | <a name="output_security_groups"></a> [security\_groups](#output\_security\_groups) | Map of current VPC's common [aws\_security\_group data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group#attribute-reference), keyed by `name` |
 | <a name="output_service"></a> [service](#output\_service) | The name of the current service or terraservice. |
-| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The current environment's VPC ID value |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The current environment VPC ID value |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/platform/README.md
+++ b/terraform/modules/platform/README.md
@@ -51,6 +51,8 @@ No modules.
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy.permissions_boundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+| [aws_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/nat_gateway) | data source |
+| [aws_nat_gateways.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/nat_gateways) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_s3_bucket.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
@@ -78,6 +80,7 @@ No modules.
 | <a name="output_is_ephemeral_env"></a> [is\_ephemeral\_env](#output\_is\_ephemeral\_env) | Returns true when environment is \_ephemeral\_, false when \_established\_ |
 | <a name="output_kion_roles"></a> [kion\_roles](#output\_kion\_roles) | Map of common kion/cloudtamer [aws\_iam\_role data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `name`. |
 | <a name="output_logging_bucket"></a> [logging\_bucket](#output\_logging\_bucket) | The designated access log bucket [aws\_s3\_bucket data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket#attribute-reference) for the current environment |
+| <a name="output_nat_gateways"></a> [nat\_gateways](#output\_nat\_gateways) | Map of current VPC's **available** [aws\_nat\_gateway data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `id`. |
 | <a name="output_parent_env"></a> [parent\_env](#output\_parent\_env) | The solution's source environment. For established environments this is equal to the environment's name |
 | <a name="output_platform_cidr"></a> [platform\_cidr](#output\_platform\_cidr) | The CIDR-range for the CDAP-managed VPC for CI and other administrative functions. |
 | <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | Map of current VPCs **private** [aws\_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `subnet_id` |

--- a/terraform/modules/platform/README.md
+++ b/terraform/modules/platform/README.md
@@ -1,0 +1,88 @@
+# Platform Child Module
+
+This is a simple child module comprised of data sources, outputs, and some modest logic to encourage adoption of emerging, platform-wide standards.
+
+<!-- BEGIN_TF_DOCS -->
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.10.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~>5 |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app"></a> [app](#input\_app) | The short name for the delivery team or ADO. | `string` | n/a | yes |
+| <a name="input_env"></a> [env](#input\_env) | The solution's environment name. | `string` | n/a | yes |
+| <a name="input_module_root"></a> [module\_root](#input\_module\_root) | The full URL to the terraform module root at issue for this infrastructure | `string` | n/a | yes |
+| <a name="input_service"></a> [service](#input\_service) | Service _or_ terraservice name. | `string` | n/a | yes |
+| <a name="input_additional_tags"></a> [additional\_tags](#input\_additional\_tags) | Additional tags to merge into final default\_tags output | `map(string)` | `{}` | no |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Modules
+
+No modules.
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy.permissions_boundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_s3_bucket.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_security_groups.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_groups) | data source |
+| [aws_ssm_parameter.platform_cidr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | The AWS account ID associated with the current caller identity |
+| <a name="output_app"></a> [app](#output\_app) | The short name for the delivery team or ADO. |
+| <a name="output_default_tags"></a> [default\_tags](#output\_default\_tags) | Tags for use in AWS provider block `default_tags`. Merges collection of standard tags with optional, user-specificed `additional_tags` |
+| <a name="output_env"></a> [env](#output\_env) | The solution's application environment name. |
+| <a name="output_is_ephemeral_env"></a> [is\_ephemeral\_env](#output\_is\_ephemeral\_env) | Returns true when environment is \_ephemeral\_, false when \_established\_ |
+| <a name="output_logging_bucket_arn"></a> [logging\_bucket\_arn](#output\_logging\_bucket\_arn) | The designated access log bucket for this current environment |
+| <a name="output_parent_env"></a> [parent\_env](#output\_parent\_env) | The solution's source environment. For established environments this is equal to the environment's name |
+| <a name="output_platform_cidr"></a> [platform\_cidr](#output\_platform\_cidr) | The CIDR-range for the CDAP-managed VPC for CI and other administrative functions. |
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | The current environment and VPC's private subnet ids |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | The current environment and VPC's public subnet ids |
+| <a name="output_region_name"></a> [region\_name](#output\_region\_name) | The region name associated with the current caller identity |
+| <a name="output_sdlc_env"></a> [sdlc\_env](#output\_sdlc\_env) | The SDLC (production vs non-production) environment. |
+| <a name="output_security_groups"></a> [security\_groups](#output\_security\_groups) | Common security groups relevant to the current environment. |
+| <a name="output_service"></a> [service](#output\_service) | The name of the current service or terraservice. |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The current environment's VPC (data.aws\_vpc) ID value. |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/platform/README.md
+++ b/terraform/modules/platform/README.md
@@ -26,7 +26,7 @@ This is a simple child module comprised of data sources, outputs, and some modes
 |------|-------------|------|---------|:--------:|
 | <a name="input_app"></a> [app](#input\_app) | The short name for the delivery team or ADO. | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | The solution's environment name. | `string` | n/a | yes |
-| <a name="input_module_root"></a> [module\_root](#input\_module\_root) | The full URL to the terraform module root at issue for this infrastructure | `string` | n/a | yes |
+| <a name="input_root_module"></a> [root\_module](#input\_root\_module) | The full URL to the terraform module root at issue for this infrastructure | `string` | n/a | yes |
 | <a name="input_service"></a> [service](#input\_service) | Service _or_ terraservice name. | `string` | n/a | yes |
 | <a name="input_additional_tags"></a> [additional\_tags](#input\_additional\_tags) | Additional tags to merge into final default\_tags output | `map(string)` | `{}` | no |
 
@@ -73,18 +73,18 @@ No modules.
 |------|-------------|
 | <a name="output_account_id"></a> [account\_id](#output\_account\_id) | The AWS account ID associated with the current caller identity |
 | <a name="output_app"></a> [app](#output\_app) | The short name for the delivery team or ADO. |
-| <a name="output_default_tags"></a> [default\_tags](#output\_default\_tags) | Tags for use in AWS provider block `default_tags`. Merges collection of standard tags with optional, user-specificed `additional_tags` |
+| <a name="output_default_tags"></a> [default\_tags](#output\_default\_tags) | Map of tags for use in AWS provider block `default_tags`. Merges collection of standard tags with optional, user-specificed `additional_tags` |
 | <a name="output_env"></a> [env](#output\_env) | The solution's application environment name. |
 | <a name="output_is_ephemeral_env"></a> [is\_ephemeral\_env](#output\_is\_ephemeral\_env) | Returns true when environment is \_ephemeral\_, false when \_established\_ |
-| <a name="output_kion_roles"></a> [kion\_roles](#output\_kion\_roles) | A map of common kion/cloudtamer `aws_iam_role` data sources organized by name. For administrative use in CMS Hybrid Cloud and DASG. |
-| <a name="output_logging_bucket"></a> [logging\_bucket](#output\_logging\_bucket) | The designated access log bucket for this current environment |
+| <a name="output_kion_roles"></a> [kion\_roles](#output\_kion\_roles) | Map of common kion/cloudtamer [aws\_iam\_role data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `name`. |
+| <a name="output_logging_bucket"></a> [logging\_bucket](#output\_logging\_bucket) | The designated access log bucket [aws\_s3\_bucket data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket#attribute-reference) for the current environment |
 | <a name="output_parent_env"></a> [parent\_env](#output\_parent\_env) | The solution's source environment. For established environments this is equal to the environment's name |
 | <a name="output_platform_cidr"></a> [platform\_cidr](#output\_platform\_cidr) | The CIDR-range for the CDAP-managed VPC for CI and other administrative functions. |
-| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | The current environment and VPC's private subnet ids |
-| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | The current environment and VPC's public subnet ids |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | Map of current VPCs **private** [aws\_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `subnet_id` |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | Map of current VPCs **public** [aws\_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `id` |
 | <a name="output_region_name"></a> [region\_name](#output\_region\_name) | The region name associated with the current caller identity |
 | <a name="output_sdlc_env"></a> [sdlc\_env](#output\_sdlc\_env) | The SDLC (production vs non-production) environment. |
-| <a name="output_security_groups"></a> [security\_groups](#output\_security\_groups) | Common security groups relevant to the current environment. |
+| <a name="output_security_groups"></a> [security\_groups](#output\_security\_groups) | Map of current VPC's common [aws\_security\_group data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group#attribute-reference), keyed by `name` |
 | <a name="output_service"></a> [service](#output\_service) | The name of the current service or terraservice. |
-| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The current environment's VPC (data.aws\_vpc) ID value. |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The current environment's VPC ID value |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/platform/README.md
+++ b/terraform/modules/platform/README.md
@@ -50,6 +50,7 @@ No modules.
 |------|------|
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy.permissions_boundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_s3_bucket.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
@@ -75,7 +76,8 @@ No modules.
 | <a name="output_default_tags"></a> [default\_tags](#output\_default\_tags) | Tags for use in AWS provider block `default_tags`. Merges collection of standard tags with optional, user-specificed `additional_tags` |
 | <a name="output_env"></a> [env](#output\_env) | The solution's application environment name. |
 | <a name="output_is_ephemeral_env"></a> [is\_ephemeral\_env](#output\_is\_ephemeral\_env) | Returns true when environment is \_ephemeral\_, false when \_established\_ |
-| <a name="output_logging_bucket_arn"></a> [logging\_bucket\_arn](#output\_logging\_bucket\_arn) | The designated access log bucket for this current environment |
+| <a name="output_kion_roles"></a> [kion\_roles](#output\_kion\_roles) | A map of common kion/cloudtamer `aws_iam_role` data sources organized by name. For administrative use in CMS Hybrid Cloud and DASG. |
+| <a name="output_logging_bucket"></a> [logging\_bucket](#output\_logging\_bucket) | The designated access log bucket for this current environment |
 | <a name="output_parent_env"></a> [parent\_env](#output\_parent\_env) | The solution's source environment. For established environments this is equal to the environment's name |
 | <a name="output_platform_cidr"></a> [platform\_cidr](#output\_platform\_cidr) | The CIDR-range for the CDAP-managed VPC for CI and other administrative functions. |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | The current environment and VPC's private subnet ids |

--- a/terraform/modules/platform/main.tf
+++ b/terraform/modules/platform/main.tf
@@ -9,8 +9,8 @@ locals {
 
   static_tags = {
     parent_env     = local.parent_env
-    env            = local.env
-    app            = local.app
+    environment    = local.env
+    application    = local.app
     business       = "oeda"
     service        = local.service
     terraform      = true

--- a/terraform/modules/platform/main.tf
+++ b/terraform/modules/platform/main.tf
@@ -109,13 +109,7 @@ data "aws_security_groups" "this" {
   }
   filter {
     name = "tag:Name"
-    values = [
-      "cmscloud-security-tools",
-      "internet",
-      "remote-management",
-      "zscaler-private",
-      "zscaler-public",
-    ]
+    values = local.aws_security_group_names
   }
 }
 

--- a/terraform/modules/platform/main.tf
+++ b/terraform/modules/platform/main.tf
@@ -84,6 +84,20 @@ data "aws_subnet" "public" {
   id       = each.key
 }
 
+data "aws_nat_gateways" "this" {
+  vpc_id = data.aws_vpc.this.id
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+data "aws_nat_gateway" "this" {
+  for_each = toset(data.aws_nat_gateways.this.ids)
+  id       = each.key
+}
+
 data "aws_s3_bucket" "access_logs" {
   bucket = local.access_logs_bucket[local.parent_env]
 }

--- a/terraform/modules/platform/main.tf
+++ b/terraform/modules/platform/main.tf
@@ -30,11 +30,11 @@ locals {
   ]
 
   aws_security_group_names = [
-      "cmscloud-security-tools",
-      "internet",
-      "remote-management",
-      "zscaler-private",
-      "zscaler-public",
+    "cmscloud-security-tools",
+    "internet",
+    "remote-management",
+    "zscaler-private",
+    "zscaler-public",
   ]
 }
 
@@ -121,5 +121,5 @@ data "aws_ssm_parameter" "platform_cidr" {
 
 data "aws_iam_role" "this" {
   for_each = toset(local.aws_iam_role_names)
-  name = each.key
+  name     = each.key
 }

--- a/terraform/modules/platform/main.tf
+++ b/terraform/modules/platform/main.tf
@@ -2,7 +2,7 @@ locals {
   app              = var.app
   env              = var.env
   established_envs = ["test", "dev", "sandbox", "prod"]
-  module_root      = var.module_root
+  root_module      = var.root_module
   parent_env       = one([for x in local.established_envs : x if can(regex("${x}$$", local.env))])
   sdlc_env         = contains(["sandbox", "prod"], local.parent_env) ? "production" : "non-production"
   service          = var.service
@@ -14,7 +14,7 @@ locals {
     business       = "oeda"
     service        = local.service
     terraform      = true
-    tf_module_root = local.module_root
+    tf_root_module = local.root_module
   }
 
   access_logs_bucket = {

--- a/terraform/modules/platform/outputs.tf
+++ b/terraform/modules/platform/outputs.tf
@@ -93,3 +93,9 @@ output "kion_roles" {
   sensitive   = false
   value       = data.aws_iam_role.this
 }
+
+output "nat_gateways" {
+  description = "Map of current VPC's **available** [aws_nat_gateway data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `id`."
+  sensitive   = true
+  value       = data.aws_nat_gateway.this
+}

--- a/terraform/modules/platform/outputs.tf
+++ b/terraform/modules/platform/outputs.tf
@@ -47,37 +47,37 @@ output "parent_env" {
 }
 
 output "default_tags" {
-  description = "Tags for use in AWS provider block `default_tags`. Merges collection of standard tags with optional, user-specificed `additional_tags`"
+  description = "Map of tags for use in AWS provider block `default_tags`. Merges collection of standard tags with optional, user-specificed `additional_tags`"
   value       = merge(var.additional_tags, local.static_tags)
   sensitive   = false
 }
 
 output "vpc_id" {
-  description = "The current environment's VPC (data.aws_vpc) ID value."
+  description = "The current environment's VPC ID value"
   sensitive   = false
   value       = data.aws_vpc.this.id
 }
 
-output "private_subnet_ids" {
-  description = "The current environment and VPC's private subnet ids"
+output "private_subnets" {
+  description = "Map of current VPCs **private** [aws_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `subnet_id`"
   sensitive   = true
   value       = data.aws_subnet.private
 }
 
-output "public_subnet_ids" {
-  description = "The current environment and VPC's public subnet ids"
+output "public_subnets" {
+  description = "Map of current VPCs **public** [aws_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `id`"
   sensitive   = true
   value       = data.aws_subnet.public
 }
 
 output "logging_bucket" {
-  description = "The designated access log bucket for this current environment"
+  description = "The designated access log bucket [aws_s3_bucket data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket#attribute-reference) for the current environment"
   value       = data.aws_s3_bucket.access_logs
   sensitive   = false
 }
 
 output "security_groups" {
-  description = "Common security groups relevant to the current environment."
+  description = "Map of current VPC's common [aws_security_group data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group#attribute-reference), keyed by `name`"
   sensitive   = true
   value       = data.aws_security_group.this
 }
@@ -89,7 +89,7 @@ output "platform_cidr" {
 }
 
 output "kion_roles" {
-  description = "A map of common kion/cloudtamer `aws_iam_role` data sources organized by name. For administrative use in CMS Hybrid Cloud and DASG."
+  description = "Map of common kion/cloudtamer [aws_iam_role data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `name`."
   sensitive   = false
   value       = data.aws_iam_role.this
 }

--- a/terraform/modules/platform/outputs.tf
+++ b/terraform/modules/platform/outputs.tf
@@ -1,0 +1,93 @@
+output "app" {
+  description = "The short name for the delivery team or ADO."
+  sensitive   = false
+  value       = local.app
+}
+
+output "service" {
+  description = "The name of the current service or terraservice."
+  sensitive   = false
+  value       = local.service
+}
+
+output "region_name" {
+  description = "The region name associated with the current caller identity"
+  sensitive   = false
+  value       = data.aws_region.this.name
+}
+
+output "account_id" {
+  description = "The AWS account ID associated with the current caller identity"
+  sensitive   = true
+  value       = data.aws_caller_identity.this.account_id
+}
+
+output "env" {
+  description = "The solution's application environment name."
+  sensitive   = false
+  value       = local.env
+}
+
+output "sdlc_env" {
+  description = "The SDLC (production vs non-production) environment."
+  sensitive   = false
+  value       = local.sdlc_env
+}
+
+output "is_ephemeral_env" {
+  description = "Returns true when environment is _ephemeral_, false when _established_"
+  sensitive   = false
+  value       = local.env != local.parent_env
+}
+
+output "parent_env" {
+  description = "The solution's source environment. For established environments this is equal to the environment's name"
+  sensitive   = false
+  value       = local.parent_env
+}
+
+output "default_tags" {
+  description = "Tags for use in AWS provider block `default_tags`. Merges collection of standard tags with optional, user-specificed `additional_tags`"
+  value       = merge(var.additional_tags, local.static_tags)
+  sensitive   = false
+}
+
+output "vpc_id" {
+  description = "The current environment's VPC (data.aws_vpc) ID value."
+  sensitive   = true
+  value       = data.aws_vpc.this.id
+}
+
+output "private_subnet_ids" {
+  description = "The current environment and VPC's private subnet ids"
+  sensitive   = true
+  value       = data.aws_subnet.private
+}
+
+output "public_subnet_ids" {
+  description = "The current environment and VPC's public subnet ids"
+  sensitive   = true
+  value       = data.aws_subnet.public
+}
+
+output "logging_bucket" {
+  description = "The designated access log bucket for this current environment"
+  value       = data.aws_s3_bucket.access_logs
+}
+
+output "security_groups" {
+  description = "Common security groups relevant to the current environment."
+  sensitive   = false
+  value       = data.aws_security_group.this
+}
+
+output "platform_cidr" {
+  value       = data.aws_ssm_parameter.platform_cidr.value
+  description = "The CIDR-range for the CDAP-managed VPC for CI and other administrative functions."
+  sensitive   = true
+}
+
+output "kion_roles" {
+  value = data.aws_iam_role.this
+  sensitive = false
+}

--- a/terraform/modules/platform/outputs.tf
+++ b/terraform/modules/platform/outputs.tf
@@ -54,7 +54,7 @@ output "default_tags" {
 
 output "vpc_id" {
   description = "The current environment's VPC (data.aws_vpc) ID value."
-  sensitive   = true
+  sensitive   = false
   value       = data.aws_vpc.this.id
 }
 
@@ -73,21 +73,23 @@ output "public_subnet_ids" {
 output "logging_bucket" {
   description = "The designated access log bucket for this current environment"
   value       = data.aws_s3_bucket.access_logs
+  sensitive   = false
 }
 
 output "security_groups" {
   description = "Common security groups relevant to the current environment."
-  sensitive   = false
+  sensitive   = true
   value       = data.aws_security_group.this
 }
 
 output "platform_cidr" {
-  value       = data.aws_ssm_parameter.platform_cidr.value
   description = "The CIDR-range for the CDAP-managed VPC for CI and other administrative functions."
   sensitive   = true
+  value       = data.aws_ssm_parameter.platform_cidr.value
 }
 
 output "kion_roles" {
-  value = data.aws_iam_role.this
-  sensitive = false
+  description = "A map of common kion/cloudtamer `aws_iam_role` data sources organized by name. For administrative use in CMS Hybrid Cloud and DASG."
+  sensitive   = false
+  value       = data.aws_iam_role.this
 }

--- a/terraform/modules/platform/outputs.tf
+++ b/terraform/modules/platform/outputs.tf
@@ -48,8 +48,8 @@ output "parent_env" {
 
 output "default_tags" {
   description = "Map of tags for use in AWS provider block `default_tags`. Merges collection of standard tags with optional, user-specificed `additional_tags`"
-  value       = merge(var.additional_tags, local.static_tags)
   sensitive   = false
+  value       = merge(var.additional_tags, local.static_tags)
 }
 
 output "vpc_id" {
@@ -72,8 +72,8 @@ output "public_subnets" {
 
 output "logging_bucket" {
   description = "The designated access log bucket [aws_s3_bucket data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket#attribute-reference) for the current environment"
-  value       = data.aws_s3_bucket.access_logs
   sensitive   = false
+  value       = data.aws_s3_bucket.access_logs
 }
 
 output "security_groups" {
@@ -90,7 +90,7 @@ output "platform_cidr" {
 
 output "kion_roles" {
   description = "Map of common kion/cloudtamer [aws_iam_role data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `name`."
-  sensitive   = false
+  sensitive   = true
   value       = data.aws_iam_role.this
 }
 

--- a/terraform/modules/platform/outputs.tf
+++ b/terraform/modules/platform/outputs.tf
@@ -53,19 +53,19 @@ output "default_tags" {
 }
 
 output "vpc_id" {
-  description = "The current environment's VPC ID value"
+  description = "The current environment VPC ID value"
   sensitive   = false
   value       = data.aws_vpc.this.id
 }
 
 output "private_subnets" {
-  description = "Map of current VPCs **private** [aws_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `subnet_id`"
+  description = "Map of current VPC **private** [aws_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `subnet_id`"
   sensitive   = true
   value       = data.aws_subnet.private
 }
 
 output "public_subnets" {
-  description = "Map of current VPCs **public** [aws_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `id`"
+  description = "Map of current VPC **public** [aws_subnet data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet), keyed by `id`"
   sensitive   = true
   value       = data.aws_subnet.public
 }
@@ -95,7 +95,7 @@ output "kion_roles" {
 }
 
 output "nat_gateways" {
-  description = "Map of current VPC's **available** [aws_nat_gateway data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `id`."
+  description = "Map of current VPC **available** [aws_nat_gateway data sources](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role#attributes-reference), keyed by `id`."
   sensitive   = true
   value       = data.aws_nat_gateway.this
 }

--- a/terraform/modules/platform/terraform.tf
+++ b/terraform/modules/platform/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>5"
+    }
+  }
+  required_version = "1.10.5"
+}

--- a/terraform/modules/platform/variables.tf
+++ b/terraform/modules/platform/variables.tf
@@ -1,0 +1,33 @@
+variable "app" {
+  description = "The short name for the delivery team or ADO."
+  type        = string
+  validation {
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Invalid short var.app (application). Must be one of ab2d, bcda, or dpc."
+  }
+}
+
+variable "env" {
+  description = "The solution's environment name."
+  type        = string
+  validation {
+    condition     = one([for x in ["test", "dev", "sandbox", "prod"] : x if can(regex("^${x}$$|^([a-z0-9]+[a-z0-9-])+([^--])-${x}$$", var.env))]) != null
+    error_message = "Invalid environment/workspace name. Must end in one of test, dev, sandbox, or prod."
+  }
+}
+
+variable "service" {
+  description = "Service _or_ terraservice name."
+  type        = string
+}
+
+variable "additional_tags" {
+  default     = {}
+  description = "Additional tags to merge into final default_tags output"
+  type        = map(string)
+}
+
+variable "module_root" {
+  description = "The full URL to the terraform module root at issue for this infrastructure"
+  type        = string
+}

--- a/terraform/modules/platform/variables.tf
+++ b/terraform/modules/platform/variables.tf
@@ -27,7 +27,7 @@ variable "additional_tags" {
   type        = map(string)
 }
 
-variable "module_root" {
+variable "root_module" {
   description = "The full URL to the terraform module root at issue for this infrastructure"
   type        = string
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1033

## 🛠 Changes

Introduces a child module for commonly referenced security groups, iam roles, subnets, and other basics that any consuming module might otherwise lookup for itself with a separate collection of data sources and input parameters. 😬 

## ℹ️ Context

This will help define the standards by which the CDAP customers operate, including setting a baseline for default tags.

## 🧪 Validation

Because this is for greenfield only, I've been able to make use of this child module in a limited capacity in the AB2D core service module–it works!
