### PR TITLE
PLT-1081 Add tf-bucket-access-logs workflow

### DIFF
--- a/.github/workflows/tf-bucket-access-logs.yml
+++ b/.github/workflows/tf-bucket-access-logs.yml
@@ -1,0 +1,49 @@
+name: tf-bucket-access-logs
+run-name: tf-bucket-access-logs ${{ inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'apply' || 'plan' }}
+
+on:
+  push:
+    paths:
+      - .github/workflows/tf-bucket-access-logs.yml
+      - terraform/services/bucket-access-logs/**
+  workflow_dispatch:
+    inputs:
+      apply:
+        required: false
+        type: boolean
+
+jobs:
+  check-fmt:
+    runs-on: codebuild-cdap-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/bucket-access-logs
+
+  plan-apply:
+    needs: check-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: codebuild-cdap-${{github.run_id}}-${{github.run_attempt}}
+    defaults:
+      run:
+        working-directory: ./terraform/services/bucket-access-logs
+    strategy:
+      fail-fast: false
+      matrix: # Only one per account
+        app: [bcda]
+        env: [test, prod]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ contains(fromJSON('["dev", "test"]'), matrix.env) && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}-gf.s3.tfbackend
+      - run: terraform plan -out=tf.plan
+        env:
+          TF_VAR_legacy: "false"
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: terraform apply -auto-approve tf.plan


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1081

## 🛠 Changes

Added the tf-bucket-access-logs workflow.

## ℹ️ Context

The tf-bucket-access-logs workflow will be used for planning and applying terraform for the access logs buckets in greenfield accounts.

## 🧪 Validation

See checks.