### PR TITLE
PLT-805 Fix run-name interpolation

### DIFF
--- a/.github/workflows/tf-api-waf.yml
+++ b/.github/workflows/tf-api-waf.yml
@@ -1,5 +1,5 @@
 name: tf-api-waf
-run-name: tf-api-waf ${{ inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'apply' || 'plan' }}
+run-name: tf-api-waf ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
 
 on:
   push:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-805

## 🛠 Changes

Fixed string interpolation in run-name for tf-api-waf workflow.

## ℹ️ Context

Runs were showing as "tf-api-waf true" instead of "tf-api-waf apply".

## 🧪 Validation

See run with correct name at https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/15189772084.