### PR TITLE
PLT-1093 Add -api suffix to ab2d lb data call

### DIFF
--- a/terraform/services/api-waf/main.tf
+++ b/terraform/services/api-waf/main.tf
@@ -11,7 +11,7 @@ locals {
     bcda = "bcda-api-${local.is_sandbox ? "opensbx" : var.env}-01"
     dpc  = "dpc-${local.is_sandbox ? "prod-sbx" : var.env}-1"
     } : {
-    ab2d = "ab2d-${var.env}"
+    ab2d = "ab2d-${var.env}-api"
     bcda = "bcda-api-${var.env}-01"
     dpc  = "dpc-${var.env}-1"
   }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1093

## 🛠 Changes

Fix for WAF terraform to get the load balancer for AB2D.

## ℹ️ Context

The data call for the load balancer in the api-waf terraform did not find the newly created ab2d load balancer in greenfield.

## 🧪 Validation

See checks. Applied with https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/15211384139/job/42786198048