### PR TITLE
PLT-1040 Extend tf-api-rds workflow to other environments

### DIFF
--- a/.github/workflows/tf-api-rds.yml
+++ b/.github/workflows/tf-api-rds.yml
@@ -34,12 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [ab2d, bcda, dpc]
-        env: [dev]
-        include:
-          - app: bcda
-            env: test
-          - app: dpc
-            env: test
+        env: [dev, test, sandbox, prod]
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1040

## 🛠 Changes

Extend the tf-api-rds workflow to plan and apply in all greenfield environments.

## ℹ️ Context

This follows up on #234 to include environments that are not yet active. Once teams have restored databases and added secrets in successive environments, this workflow can be run again to apply terraform.

## 🧪 Validation

See checks. Plan and apply on environments that have not yet been built out for rds are expected to fail.