### PR TITLE
PLT-1031: Remove DPC Prod from api-waf-sync lambda terraform

### DIFF
--- a/.github/workflows/tf-api-waf-sync.yml
+++ b/.github/workflows/tf-api-waf-sync.yml
@@ -40,6 +40,9 @@ jobs:
       matrix:
         app: [bcda, dpc]
         env: [dev, test, prod]
+        exclude:
+          - app: dpc
+            env: prod
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1031

## 🛠 Changes

Removed DPC prod environment from api-waf-sync workflow

## ℹ️ Context

We don't actually run the WAF sync in the prod environment on legacy. It was added in error to the new workflow for greenfield.

## 🧪 Validation

WAF sync function should not be operating on DPC GF prod environment
