### PR TITLE
PLT-1119 Add prewarm script

### DIFF
--- a/scripts/prewarm.sql
+++ b/scripts/prewarm.sql
@@ -1,0 +1,45 @@
+-- Run this script following a postgres DB restore in RDS to get data out of
+-- lazy loading. On a ~250GB database, this takes around 15 minutes. A VACUUM
+-- FULL on the same database takes hours. This script does the following:
+--
+-- - Runs VACUUM ANALYZE to update postgres stats on relpages, etc.
+-- - Prints out the table of relations to be warmed
+-- - Enables the pg_prewarm extension if it hasn't been enabled already
+-- - Prints out the relation name and number of blocks warmed as it loops
+--
+-- This script must be run on each database in the cluster. To run with
+-- timing in psql:
+--   postgres=> \timing
+--   postgres=> \c postgres
+--   postgres=> \i prewarm.sql
+
+-- Run VACUUM ANALYZE to update postgres stats on relpages, etc.
+VACUUM ANALYZE;
+
+-- Create and print out the table of relations to be warmed
+DROP TABLE IF EXISTS warmrels;
+CREATE TEMP TABLE warmrels AS
+  SELECT c.oid, c.relkind, c.relpages, c.relname
+  FROM pg_class c
+  JOIN pg_user u ON u.usesysid = c.relowner
+  WHERE u.usename NOT IN ('rdsadmin', 'rdsrepladmin', ' pg_signal_backend', 'rds_superuser', 'rds_replication')
+  AND c.relkind NOT IN ('v', 'I', 'p')
+  ORDER BY c.relpages ASC;
+SELECT * FROM warmrels;
+
+-- Enable the pg_prewarm extension if it hasn't been enabled already
+CREATE EXTENSION IF NOT EXISTS pg_prewarm;
+
+-- Prewarm each relation, printing out the name and number of blocks warmed
+DO $$
+DECLARE
+  rel RECORD;
+  numblocks int8;
+BEGIN
+  FOR rel IN SELECT * FROM warmrels LOOP
+    RAISE INFO 'relname: %', rel.relname;
+    SELECT pg_prewarm(rel.oid) INTO numblocks;
+    RAISE INFO 'numblocks: %', numblocks;
+  END LOOP;
+END
+$$;

--- a/scripts/prewarm.sql
+++ b/scripts/prewarm.sql
@@ -9,9 +9,10 @@
 --
 -- This script must be run on each database in the cluster. To run with
 -- timing in psql:
+--
 --   postgres=> \timing
---   postgres=> \c postgres
---   postgres=> \i prewarm.sql
+--   postgres=> \c prod
+--   prod=> \i prewarm.sql
 
 -- Run VACUUM ANALYZE to update postgres stats on relpages, etc.
 VACUUM ANALYZE;


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1119

## 🛠 Changes

Added SQL script for running prewarm across tables.

## ℹ️ Context

Following restore of a PostgreSQL database in RDS, initial queries can be slowed by lazy loading of data from S3. This script follows [AWS recommendations](https://aws.amazon.com/blogs/database/amazon-rds-snapshot-restore-and-recovery-demystified/) to use the pg_prewarm extension to read blocks, effectively loading data in preparation for queries. We were previously running VACUUM FULL over databases following a restore, which took several hours unnecessarily rewriting tables and indexes.

To ensure data readiness following a restore, this could be followed up by SELECT queries specific to each team's data for common API queries.

## 🧪 Validation

Run on a restore of the bcda-prod db, this script takes roughly 15 minutes (see output below). It also runs without error on the ab2d-prod database.

```
bcda=> \i prewarm.sql
VACUUM
Time: 225643.669 ms (03:45.644)
psql:prewarm.sql:3: NOTICE:  table "warmrels" does not exist, skipping
DROP TABLE
Time: 96.686 ms
SELECT 132
Time: 689.072 ms
   oid   | relkind | relpages |                relname
---------+---------+----------+----------------------------------------
   46539 | r       | 11568822 | cclf_beneficiaries
   46567 | i       |  4712117 | idx_cclf_beneficiaries_file_id
   46565 | i       |  3828353 | cclf_beneficiaries_pkey
...
 1100922 | t       |        0 | pg_toast_1100917
   46402 | r       |        0 | alr
   46410 | r       |        0 | alr_meta
(132 rows)

Time: 61.339 ms
CREATE EXTENSION
Time: 115.614 ms
psql:prewarm.sql:29: INFO:  relname: cclf_beneficiaries
psql:prewarm.sql:29: INFO:  numblocks: 11568822
psql:prewarm.sql:29: INFO:  relname: idx_cclf_beneficiaries_file_id
psql:prewarm.sql:29: INFO:  numblocks: 4712117
...
psql:prewarm.sql:29: INFO:  relname: alr
psql:prewarm.sql:29: INFO:  numblocks: 0
psql:prewarm.sql:29: INFO:  relname: alr_meta
psql:prewarm.sql:29: INFO:  numblocks: 0
DO
Time: 677294.575 ms (11:17.295)
```