### PR TITLE
PLT-1131: Add files for NAT gateways to external-services sync workflow

### DIFF
--- a/.github/workflows/sync-external-services-ip-sets.yml
+++ b/.github/workflows/sync-external-services-ip-sets.yml
@@ -46,5 +46,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - name: Run IP set sync script
         run: |
-          scripts/sync-ip-set --name=external-services --scope=REGIONAL cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt
-          scripts/sync-ip-set --name=external-services --scope=CLOUDFRONT cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt
+          scripts/sync-ip-set --name=external-services --scope=REGIONAL cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/non-prod-nat.txt cidr/prod-nat.txt
+          scripts/sync-ip-set --name=external-services --scope=CLOUDFRONT cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/non-prod-nat.txt cidr/prod-nat.txt


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1131

## 🛠 Changes

Adds two files, one for each account, to the external-services sync workflow.

## ℹ️ Context

When applied, this will add the public NAT gateway IPs to the external-services allowlist to let the teams reach their public load balancers from resources on the same account.

## 🧪 Validation

Once this is applied, we should see the IPs added in https://github.com/CMSgov/cdap-private/pull/8 in the external-services IP set.
