### PR TITLE
PLT-1119 Select tables with relpages

### DIFF
--- a/scripts/prewarm.sql
+++ b/scripts/prewarm.sql
@@ -25,6 +25,7 @@ CREATE TEMP TABLE warmrels AS
   JOIN pg_user u ON u.usesysid = c.relowner
   WHERE u.usename NOT IN ('rdsadmin', 'rdsrepladmin', ' pg_signal_backend', 'rds_superuser', 'rds_replication')
   AND c.relkind NOT IN ('v', 'I', 'p')
+  AND c.relpages > 0
   ORDER BY c.relpages ASC;
 SELECT * FROM warmrels;
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1119

## 🛠 Changes

Updated the warmrels table select to not include tables without relpages. 

## ℹ️ Context

Tables without relpages should not need to be prewarmed, and this avoids including the warmrels table itself in the list, which was resutling in `ERROR:  cannot access temporary tables of other sessions`.

## 🧪 Validation

Tested on ab2d dev database.