### PR TITLE
PLT-1040 Follow-up fixes on api-rds

### DIFF
--- a/.github/workflows/tf-api-rds.yml
+++ b/.github/workflows/tf-api-rds.yml
@@ -1,5 +1,5 @@
 name: tf-api-rds
-run-name: tf-api-rds ${{ inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'apply' || 'plan' }}
+run-name: tf-api-rds ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
 
 on:
   push:

--- a/.github/workflows/tf-api-rds.yml
+++ b/.github/workflows/tf-api-rds.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [ab2d, bcda, dpc]
+        app: [bcda, dpc]
         env: [dev, test, sandbox, prod]
     steps:
       - uses: actions/checkout@v4

--- a/terraform/services/api-rds/data.tf
+++ b/terraform/services/api-rds/data.tf
@@ -32,7 +32,7 @@ locals {
 
 # Fetching the secret for database username
 data "aws_secretsmanager_secret" "database_user" {
-  name = local.db_username
+  name = var.legacy ? local.db_username : "${var.app}/${var.env}/db/username"
 }
 
 data "aws_secretsmanager_secret_version" "database_user" {
@@ -41,7 +41,7 @@ data "aws_secretsmanager_secret_version" "database_user" {
 
 # Fetching the secret for database password
 data "aws_secretsmanager_secret" "database_password" {
-  name = local.db_password
+  name = var.legacy ? local.db_password : "${var.app}/${var.env}/db/password"
 }
 
 data "aws_secretsmanager_secret_version" "database_password" {

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -263,10 +263,10 @@ resource "aws_db_instance" "api" {
   ]
 
   #NOTE: Differences between secretsmanager representations yields these ternary expression
-  # - ab2d uses plaintext
-  # - bcda/dpc use key-value storage
-  username = var.app == "ab2d" ? data.aws_secretsmanager_secret_version.database_user.secret_string : jsondecode(data.aws_secretsmanager_secret_version.database_user.secret_string).username
-  password = var.app == "ab2d" ? data.aws_secretsmanager_secret_version.database_password.secret_string : jsondecode(data.aws_secretsmanager_secret_version.database_password.secret_string).password
+  # - ab2d in legacy uses plaintext
+  # - all others use key-value storage
+  username = var.legacy && var.app == "ab2d" ? data.aws_secretsmanager_secret_version.database_user.secret_string : jsondecode(data.aws_secretsmanager_secret_version.database_user.secret_string).username
+  password = var.legacy && var.app == "ab2d" ? data.aws_secretsmanager_secret_version.database_password.secret_string : jsondecode(data.aws_secretsmanager_secret_version.database_password.secret_string).password
 
   tags = var.legacy ? merge(
     {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1040

## 🛠 Changes

Fix the run-name to print "tf-api-rds apply" when inputs.apply is true. Get secrets for the database from a standard secret path. Dropped ab2d from the workflow by request.

## ℹ️ Context

This is a follow-up on #240 to address issues seen in applying.

## 🧪 Validation

See apply at https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/15591371735.