### PR TITLE
PLT-1131: Add prod/non-prod conditional to external-services sync

### DIFF
--- a/.github/workflows/sync-external-services-ip-sets.yml
+++ b/.github/workflows/sync-external-services-ip-sets.yml
@@ -46,5 +46,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - name: Run IP set sync script
         run: |
-          scripts/sync-ip-set --name=external-services --scope=REGIONAL cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/${{ matrix.env == 'test' && 'non-' }}prod-nat.txt
-          scripts/sync-ip-set --name=external-services --scope=CLOUDFRONT cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/${{ matrix.env == 'test' && 'non-' }}prod-nat.txt
+          scripts/sync-ip-set --name=external-services --scope=REGIONAL cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/${{ matrix.env == 'test' && 'non-prod' || 'prod' }}-nat.txt
+          scripts/sync-ip-set --name=external-services --scope=CLOUDFRONT cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/${{ matrix.env == 'test' && 'non-prod' || 'prod' }}-nat.txt

--- a/.github/workflows/sync-external-services-ip-sets.yml
+++ b/.github/workflows/sync-external-services-ip-sets.yml
@@ -46,5 +46,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - name: Run IP set sync script
         run: |
-          scripts/sync-ip-set --name=external-services --scope=REGIONAL cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/non-prod-nat.txt cidr/prod-nat.txt
-          scripts/sync-ip-set --name=external-services --scope=CLOUDFRONT cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/non-prod-nat.txt cidr/prod-nat.txt
+          scripts/sync-ip-set --name=external-services --scope=REGIONAL cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/${{ matrix.env == 'test' && 'non-' }}prod-nat.txt
+          scripts/sync-ip-set --name=external-services --scope=CLOUDFRONT cidr/cdap-mgmt.txt cidr/new-relic.txt cidr/zscaler-public.txt cidr/${{ matrix.env == 'test' && 'non-' }}prod-nat.txt


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1131

## 🛠 Changes

Fixes an issue where we were including non-prod NAT Gateway IPs in the production environment and vice-versa.

## ℹ️ Context

We'd like for our team's public load balancers to be available to resources on the same account, but not non-prod<->prod.

## 🧪 Validation

Runs cleanly: https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/15593497148
