### PR TITLE
BCDA-9143: Update aco creds bucket name for GF

### DIFF
--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -30,6 +30,7 @@ data "aws_iam_policy_document" "kms_access" {
 }
 
 data "aws_iam_policy_document" "kms_generate" {
+  count = var.legacy ? 1 : 0
   statement {
     actions   = ["kms:GenerateDataKey"]
     resources = [data.aws_kms_alias.aco_creds_kms[0].target_key_arn]
@@ -53,7 +54,7 @@ module "admin_create_aco_creds_function" {
   function_role_inline_policies = var.legacy ? {
     assume-bucket-role       = data.aws_iam_policy_document.creds_bucket.json
     assume-kms-role          = data.aws_iam_policy_document.kms_access.json
-    assume-kms-generate-role = data.aws_iam_policy_document.kms_generate.json
+    assume-kms-generate-role = data.aws_iam_policy_document.kms_generate[0].json
   } : { assume-bucket-role = data.aws_iam_policy_document.creds_bucket.json }
 
   environment_variables = {

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -49,11 +49,11 @@ module "admin_create_aco_creds_function" {
 
   memory_size = local.memory_size
 
-  function_role_inline_policies = {
+  function_role_inline_policies = var.legacy ? {
     assume-bucket-role       = data.aws_iam_policy_document.creds_bucket.json
     assume-kms-role          = data.aws_iam_policy_document.kms_access.json
     assume-kms-generate-role = data.aws_iam_policy_document.kms_generate.json
-  }
+  } : { assume-bucket-role = data.aws_iam_policy_document.creds_bucket.json }
 
   environment_variables = {
     ENV      = var.env

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -10,7 +10,8 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 data "aws_kms_alias" "aco_creds_kms" {
-  name = "alias/bcda-aco-creds-kms"
+  count = var.legacy ? 1 : 0
+  name  = "alias/bcda-aco-creds-kms"
 }
 
 data "aws_iam_policy_document" "creds_bucket" {

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -2,6 +2,7 @@ locals {
   full_name   = "${var.app}-${var.env}-admin-create-aco-creds"
   db_sg_name  = var.legacy ? "bcda-${var.env == "sbx" ? "opensbx" : var.env}-rds" : "bcda-${var.env}-db"
   memory_size = 256
+  creds_bucket_name = var.legacy ? ("bcda-aco-credentials/${var.env == "sbx" ? "opensbx" : var.env}/*") : ("bcda-${var.env}-aco-creds-*")
 }
 
 data "aws_caller_identity" "current" {}
@@ -15,7 +16,7 @@ data "aws_kms_alias" "aco_creds_kms" {
 data "aws_iam_policy_document" "creds_bucket" {
   statement {
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::bcda-aco-credentials/${var.env == "sbx" ? "opensbx" : var.env}/*"]
+    resources = ["arn:aws:s3:::${local.creds_bucket_name}"]
   }
 }
 

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -1,7 +1,7 @@
 locals {
-  full_name   = "${var.app}-${var.env}-admin-create-aco-creds"
-  db_sg_name  = var.legacy ? "bcda-${var.env == "sbx" ? "opensbx" : var.env}-rds" : "bcda-${var.env}-db"
-  memory_size = 256
+  full_name         = "${var.app}-${var.env}-admin-create-aco-creds"
+  db_sg_name        = var.legacy ? "bcda-${var.env == "sbx" ? "opensbx" : var.env}-rds" : "bcda-${var.env}-db"
+  memory_size       = 256
   creds_bucket_name = var.legacy ? ("bcda-aco-credentials/${var.env == "sbx" ? "opensbx" : var.env}/*") : ("bcda-${var.env}-aco-creds-*")
 }
 

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "kms_access" {
 data "aws_iam_policy_document" "kms_generate" {
   statement {
     actions   = ["kms:GenerateDataKey"]
-    resources = [data.aws_kms_alias.aco_creds_kms.target_key_arn]
+    resources = [data.aws_kms_alias.aco_creds_kms[0].target_key_arn]
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9143

## 🛠 Changes

The aco creds output bucket name is changed for Greenfield.
The IAM policies for the lambda are updated to remove encryption/KMS rules for Greenfield.

## ℹ️ Context

Our bucket naming strategy and s3 encryption management have changed for greenfield, and the Create ACO Creds lambda must be updated accordingly. The legacy settings were left untouched, and they can be removed when the rest of the legacy variables are removed. 

In particular, in our legacy infrastructure we managed our s3 encryption ourselves, including a key and roles that were assigned to the lambda function. In greenfield, this encryption is handled by default by AWS, so we can remove a lot of our custom configuration.

Related PR which added the bucket to greenfield: https://github.com/CMSgov/bcda-ops/pull/1220

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
