### PR TITLE
PLT-1130:Create Roles and Policies for each API

### DIFF
--- a/terraform/services/snyk-integration/main.tf
+++ b/terraform/services/snyk-integration/main.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "snyk_pull" {
 
   # Scoped actions restricted to each app’s ECR repos
   statement {
-    sid    = "${title(each.key)}SnykAllowPull"
+    sid    = "${title(each.key)}SnykAllowScopedRepoActions"
     effect = "Allow"
     actions = [
       "ecr:ListTagsForResource",

--- a/terraform/services/snyk-integration/main.tf
+++ b/terraform/services/snyk-integration/main.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "snyk_pull" {
   for_each = toset(local.app)
 
   statement {
-    sid    = "${title(each.key)}SnykAllowGlobalActions"
+    sid    = "${title(each.key)}SnykAllowPull"
     effect = "Allow"
     actions = [
       "ecr:GetAuthorizationToken",
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "snyk_pull" {
 
   # Scoped actions restricted to each app’s ECR repos
   statement {
-    sid    = "${title(each.key)}SnykAllowScopedRepoActions"
+    sid    = "${title(each.key)}SnykAllowPull"
     effect = "Allow"
     actions = [
       "ecr:ListTagsForResource",

--- a/terraform/services/snyk-integration/main.tf
+++ b/terraform/services/snyk-integration/main.tf
@@ -9,7 +9,8 @@ data "aws_iam_policy" "developer_boundary_policy" {
 }
 
 data "aws_ssm_parameter" "external_id" {
-  name = "/snyk-integration/external-id"
+  for_each = toset(local.app)
+  name     = "/${each.key}/snyk-integration/external-id"
 }
 
 data "aws_ssm_parameter" "ecr_integration_user" {
@@ -17,6 +18,8 @@ data "aws_ssm_parameter" "ecr_integration_user" {
 }
 
 data "aws_iam_policy_document" "snyk_trust" {
+  for_each = toset(local.app)
+
   statement {
     effect = "Allow"
     principals {
@@ -27,7 +30,7 @@ data "aws_iam_policy_document" "snyk_trust" {
     condition {
       test     = "StringEquals"
       variable = "sts:ExternalId"
-      values   = [data.aws_ssm_parameter.external_id.value]
+      values   = [data.aws_ssm_parameter.external_id[each.key].value]
     }
   }
 }
@@ -36,25 +39,36 @@ data "aws_iam_policy_document" "snyk_pull" {
   for_each = toset(local.app)
 
   statement {
-    sid    = "${title(each.key)}SnykAllowPull"
+    sid    = "${title(each.key)}SnykAllowGlobalActions"
     effect = "Allow"
     actions = [
-      "ecr:GetLifecyclePolicyPreview",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:DescribeImages",
       "ecr:GetAuthorizationToken",
-      "ecr:DescribeRepositories",
+      "ecr:DescribeRepositories"
+    ]
+    resources = ["*"]
+  }
+
+  # Scoped actions restricted to each app’s ECR repos
+  statement {
+    sid    = "${title(each.key)}SnykAllowScopedRepoActions"
+    effect = "Allow"
+    actions = [
       "ecr:ListTagsForResource",
       "ecr:ListImages",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetRepositoryPolicy"
+      "ecr:GetRepositoryPolicy",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability"
     ]
     resources = [
       "arn:aws:ecr:us-east-1:${data.aws_caller_identity.current.account_id}:repository/${each.key}-*"
     ]
   }
 }
+
 
 resource "aws_iam_role_policy" "snyk_pull" {
   for_each = toset(local.app)
@@ -69,6 +83,6 @@ resource "aws_iam_role" "snyk" {
 
   name                 = "${each.key}-snyk"
   path                 = "/delegatedadmin/developer/"
-  assume_role_policy   = data.aws_iam_policy_document.snyk_trust.json
+  assume_role_policy   = data.aws_iam_policy_document.snyk_trust[each.key].json
   permissions_boundary = data.aws_iam_policy.developer_boundary_policy.arn
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1130

## 🛠 Changes

The policy was updated to separate global actions required by Snyk (ecr:GetAuthorizationToken, ecr:DescribeRepositories) from scoped repository actions, which are now restricted to only teams e.g bcda-*, dpc-*, ab2d-* ECR repositories.

## ℹ️ Context
This change ensures each team (e.g., BCDA, AB2D, DPC) can only scan their own ECR repositories in Snyk by restricting repository-level permissions in IAM policies. While Snyk requires global access to list all repositories (ecr:DescribeRepositories), teams can only add and scan images from their respective repos.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

See checks.
link to successful tf plan https://github.com/CMSgov/ab2d-bcda-dpc-platform/actions/runs/15692016486/job/44209308692?pr=253.

please note plan fails for legacy account because snyk external id's was not updated in param store for legacy account

role ARN snyk integration tested see comments and screenshot of snyk integration behavior for this role and policy on Jira ticket