### PR TITLE
PLT-1107 Switch encryption for bucket-access-logs bucket to AES256

### DIFF
--- a/terraform/services/bucket-access-logs/main.tf
+++ b/terraform/services/bucket-access-logs/main.tf
@@ -18,9 +18,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_access_log
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      # Encryption must be AES256. See the final bullet in the alert box at the top of
+      # https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html
+      sse_algorithm = "AES256"
     }
-    bucket_key_enabled = true
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1107

## 🛠 Changes

Switched encryption for bucket to AES256.

## ℹ️ Context

With encryption set to KMS, the key used for server access logs in the bucket (arn:aws:kms:us-east-1:858827067514:key/6deaa81f-b9df-49cd-9405-fda86975d6d3) is owned by the logging service. We cannot decrypt objects encrypted with this key. As noted in the alert box at https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html, AES-256 is the only default encryption supported.

## 🧪 Validation

See checks.