### PR TITLE
PLT-1152: Ensure DPC sandbox RDS deployment is single-az

### DIFF
--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -252,7 +252,7 @@ resource "aws_db_instance" "api" {
   backup_window                         = var.app == "dpc" || var.app == "bcda" ? "05:00-05:30" : null #1 am EST
   copy_tags_to_snapshot                 = var.app == "bcda" || var.app == "dpc" ? true : false
   kms_key_id                            = var.legacy && (var.app == "ab2d" || var.app == "dpc") ? data.aws_kms_alias.main_kms[0].target_key_arn : data.aws_kms_alias.default_rds.target_key_arn
-  multi_az                              = var.app == "dpc" ? (local.stdenv == "prod" || local.stdenv == "prod-sbx") : (var.env == "prod" || var.app == "bcda" ? true : false)
+  multi_az                              = var.app == "dpc" ? (var.env == "prod" || var.env == "sandbox") : (var.env == "prod" || var.app == "bcda" ? true : false)
   vpc_security_group_ids = var.legacy ? var.app == "bcda" || var.app == "dpc" ? concat([aws_security_group.sg_database.id], local.gdit_security_group_ids) : [
     aws_security_group.sg_database.id,
     ] : [

--- a/terraform/services/api-rds/main.tf
+++ b/terraform/services/api-rds/main.tf
@@ -252,7 +252,7 @@ resource "aws_db_instance" "api" {
   backup_window                         = var.app == "dpc" || var.app == "bcda" ? "05:00-05:30" : null #1 am EST
   copy_tags_to_snapshot                 = var.app == "bcda" || var.app == "dpc" ? true : false
   kms_key_id                            = var.legacy && (var.app == "ab2d" || var.app == "dpc") ? data.aws_kms_alias.main_kms[0].target_key_arn : data.aws_kms_alias.default_rds.target_key_arn
-  multi_az                              = var.app == "dpc" ? (var.env == "prod" || var.env == "sandbox") : (var.env == "prod" || var.app == "bcda" ? true : false)
+  multi_az                              = var.env == "prod" ? true : false
   vpc_security_group_ids = var.legacy ? var.app == "bcda" || var.app == "dpc" ? concat([aws_security_group.sg_database.id], local.gdit_security_group_ids) : [
     aws_security_group.sg_database.id,
     ] : [


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1152

## 🛠 Changes

Changes the ternary conditional to enable multi-AZ deployments for only production RDS instances.

## ℹ️ Context

As per the infrastructure meeting on 6/18: We're fine to keep multi-AZ RDS deployments in the production environments and remove them from sandbox.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
