### PR TITLE
DPC-4713: SNS To Slack lambda

### DIFF
--- a/terraform/services/sns-to-slack/README.md
+++ b/terraform/services/sns-to-slack/README.md
@@ -7,7 +7,7 @@ This service sets up the infrastructure for the sns-to-slack lambda function in 
 Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
 
 ```bash
-terraform init -backend-config=../../backends/dpc-dev.s3.tfbackend
+terraform init -backend-config=../../backends/dpc-dev-gf.s3.tfbackend
 terraform apply
 ```
 

--- a/terraform/services/sns-to-slack/README.md
+++ b/terraform/services/sns-to-slack/README.md
@@ -1,0 +1,16 @@
+# Terraform for sns-to-slack function and associated infra
+
+This service sets up the infrastructure for the sns-to-slack lambda function in upper and lower environments for DPC
+
+## Manual deploy
+
+Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
+
+```bash
+terraform init -backend-config=../../backends/dpc-dev.s3.tfbackend
+terraform apply
+```
+
+## Automated deploy
+
+This terraform is automatically applied on merge to main by the sns-to-slack-apply.yml workflow.

--- a/terraform/services/sns-to-slack/main.tf
+++ b/terraform/services/sns-to-slack/main.tf
@@ -1,7 +1,7 @@
 locals {
   full_name = "${var.app}-${var.env}-sns-to-slack"
   handler_name = {
-    dpc  = "bootstrap"
+    dpc = "bootstrap"
   }
 }
 
@@ -26,9 +26,9 @@ module "sns_to_slack_function" {
 
 # Set up queue for receiving messages when a cloudwatch alert is sent
 data "aws_sns_topic" "cloudwatch" {
-  name              = "${var.app}-${var.env}-cloudwatch-alarms"
+  name = "${var.app}-${var.env}-cloudwatch-alarms"
 }
-  
+
 module "sns_to_slack_queue" {
   source = "../../modules/queue"
 

--- a/terraform/services/sns-to-slack/main.tf
+++ b/terraform/services/sns-to-slack/main.tf
@@ -1,0 +1,39 @@
+locals {
+  full_name = "${var.app}-${var.env}-sns-to-slack"
+  handler_name = {
+    dpc  = "bootstrap"
+  }
+}
+
+module "sns_to_slack_function" {
+  source = "../../modules/function"
+
+  app    = var.app
+  env    = var.env
+  legacy = false
+
+  name        = local.full_name
+  description = "Listens for CloudWatch Alerts and forwards to Slack"
+
+  handler = local.handler_name[var.app]
+  runtime = "provided.al2"
+
+  environment_variables = {
+    ENV      = var.env
+    APP_NAME = "${var.app}-${var.env}-sns-to-slack"
+  }
+}
+
+# Set up queue for receiving messages when a cloudwatch alert is sent
+data "aws_sns_topic" "cloudwatch" {
+  name              = "${var.app}-${var.env}-cloudwatch-alarms"
+}
+  
+module "sns_to_slack_queue" {
+  source = "../../modules/queue"
+
+  name = local.full_name
+
+  function_name = module.sns_to_slack_function.name
+  sns_topic_arn = data.aws_sns_topic.cloudwatch.arn
+}

--- a/terraform/services/sns-to-slack/outputs.tf
+++ b/terraform/services/sns-to-slack/outputs.tf
@@ -1,0 +1,11 @@
+output "function_role_arn" {
+  value = module.sns_to_slack_function.role_arn
+}
+
+output "sqs_queue_arn" {
+  value = module.sns_to_slack_queue.arn
+}
+
+output "zip_bucket" {
+  value = module.sns_to_slack_function.zip_bucket
+}

--- a/terraform/services/sns-to-slack/terraform.tf
+++ b/terraform/services/sns-to-slack/terraform.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      application = var.app
+      business    = "oeda"
+      code        = "https://github.com/CMSgov/ab2d-bcda-dpc-platform/tree/main/terraform/services/sns-to-slack"
+      component   = "sns-to-slack"
+      environment = var.env
+      terraform   = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "sns-to-slack/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/terraform/services/sns-to-slack/terraform.tf
+++ b/terraform/services/sns-to-slack/terraform.tf
@@ -14,6 +14,5 @@ provider "aws" {
 terraform {
   backend "s3" {
     key = "sns-to-slack/terraform.tfstate"
-    region = "us-east-1"
   }
 }

--- a/terraform/services/sns-to-slack/variables.tf
+++ b/terraform/services/sns-to-slack/variables.tf
@@ -1,0 +1,17 @@
+variable "app" {
+  description = "The application name (dpc)"
+  type        = string
+  validation {
+    condition     = contains(["dpc"], var.app)
+    error_message = "Valid value for app is dpc."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, sandbox,prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "sandbox", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, sandbox, or prod."
+  }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4713

## 🛠 Changes

Added lambda triggered by sns message.

## ℹ️ Context

We are no longer allowed to use ChatBot to send messages to dpc-alerts from AWS, so we are following a recommendation to have alerts sent to a lambda that sends them to a slack webhook. This PR just makes the infrastructure for the lambda.

## 🧪 Validation

Terraform plan returned
`Plan: 24 to add, 0 to change, 0 to destroy.`
