### PR TITLE
DPC-4815 update cluster id for dpc-test

### DIFF
--- a/terraform/services/opt-out-export/main.tf
+++ b/terraform/services/opt-out-export/main.tf
@@ -23,7 +23,7 @@ locals {
     bcda = data.aws_iam_policy_document.bcda_policies.json
     dpc  = data.aws_iam_policy_document.dpc_policies.json
   }
-  cluster_identifier = var.app == "dpc" && var.env == "test" ? "dpc-test" : "${var.app}-${var.env}-aurora"
+  cluster_identifier = var.app == "dpc" ? "dpc-${var.env}" : "${var.app}-${var.env}-aurora"
 }
 
 data "aws_ssm_parameter" "bfd_account" {

--- a/terraform/services/opt-out-import/main.tf
+++ b/terraform/services/opt-out-import/main.tf
@@ -7,7 +7,7 @@ locals {
     bcda = data.aws_iam_policy_document.bcda_policies.json
     dpc  = data.aws_iam_policy_document.dpc_policies.json
   }
-  cluster_identifier = var.app == "dpc" && var.env == "test" ? "dpc-test" : "${var.app}-${var.env}-aurora"
+  cluster_identifier = var.app == "dpc" ? "dpc-${var.env}" : "${var.app}-${var.env}-aurora"
 }
 
 data "aws_ssm_parameter" "bfd_account" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4815

## 🛠 Changes

Cluster identifier for db for dpc opt out lambdas changed to dpc-env instead of dpc-env-aurora

## ℹ️ Context

The dpc aurora databases use a different naming convention than before, and it needs to change so our lambdas work.

## 🧪 Validation

Passes validation. Manual deploy led to passing tests in dpc

- Export: https://github.com/CMSgov/dpc-app/actions/runs/16948620744
- Import: https://github.com/CMSgov/dpc-app/actions/runs/16948606150
