### PR TITLE
BCDA-9400 Add lifecycle mgmt to filtered s3 buckets

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -119,10 +119,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
   rule {
-    id     = "noncurrent-ia"
+    id     = "noncurrent-ia-tagged"
     status = "Enabled"
 
-    # Filter to only apply to objects with the lifecycle-transition:ia tag
     filter {
       tag {
         key   = "lifecycle-transition"
@@ -130,13 +129,16 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
       }
     }
 
-    # Transition noncurrent versions to Standard-IA after 3 days
     noncurrent_version_transition {
       noncurrent_days = 3
       storage_class   = "STANDARD_IA"
     }
+  }
 
-    # Clean up incomplete multipart uploads
+  rule {
+    id     = "cleanup-multipart"
+    status = "Enabled"
+
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
     }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9400

## 🛠 Changes

- Added lifecycle management to S3 buckets that have a tag of `lifecycle-transition` and value set to `ia`
- When new versions of objects are uploaded (like new Lambda deployment packages), the previous versions will automatically transition to Standard-IA storage after 3 days

## ℹ️ Context

We were not using lifecycle transitions on our buckets, and a Security Hub control failed. Remediating it by adding a basic lifecycle transition.

## 🧪 Validation

Using the AWS console when the Lambda is deployed into lower environments.
