### PR TITLE
BCDA-9402: Setting SSM Param referenced in Ops

### DIFF
--- a/terraform/services/bucket-access-logs/main.tf
+++ b/terraform/services/bucket-access-logs/main.tf
@@ -76,8 +76,8 @@ resource "aws_s3_bucket_policy" "bucket_access_logs" {
 }
 
 resource "aws_ssm_parameter" "bucket_access_logs" {
-  name  = "/cdap/bucket-access-logs-bucket"
-  value = aws_s3_bucket.bucket_access_logs.id
-  type  = "String"
+  name        = "/cdap/bucket-access-logs-bucket"
+  value       = aws_s3_bucket.bucket_access_logs.id
+  type        = "String"
   description = "S3 bucket for storing access logs from other buckets"
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9402

## 🛠 Changes

Setting `/cdap/bucket-access-logs-bucket` SSM param. It is [referenced by the bcda-ops repo](https://github.com/CMSgov/bcda-ops/blob/88efaef80ba929fbfd3ca93ac6bd23eae3032ebd/terraform_gf/modules/s3/main.tf#L61) when creating the RPM bucket failing control, but it is never set in the CDAP repo.

## ℹ️ Context

S3 buckets for BCDA have a Security Hub failure. S3 general-purpose buckets should have server access logging enabled.
Resource(s) failing this control: arn:aws:s3:::bcda-rpms-202533514245-us-east-1
