### PR TITLE
[DPC-5291] Remove SSM parameter repo_list from ecr-cleanup lambda

### DIFF
--- a/terraform/services/ecr-cleanup/README.md
+++ b/terraform/services/ecr-cleanup/README.md
@@ -28,10 +28,19 @@ Lifecycle functions should mark image `status` with either `PROTECT` or `DELETE`
  - For each lifecycle, add the function (along with additional arguments) to the tuple. These functions will run in order.
 
 ## Dry Run
-Dry runs are available locally via the command line. First, set your AWS credentials for the environment you want to invoke. Then pass in the name of the repository (or 'all'). Output will be all images that will be deleted.
+Dry runs are available locally via the command line. 
+- First, set your AWS credentials for the environment you want to invoke (e.g. `kion stak`). 
+- Then set up a .json file to reflect repositories you want to test (e.g. `terraform/services/ecr-cleanup/lambda_src/dry_run_config.json`)
+- Output will be all images that would be deleted in a deployed environment.
 
+#### Example
 ```bash
-python lambda_function.py dpc-attribution
+cd lambda_src
+python3 -m venv venv && source venv/bin/activate
+# Testing new config file
+python3 dry_run.py --config-path path/to/new_config.json
+# Defaults to existing dry_run_config.json with DPC strategies
+python3 dry_run.py
 ```
 
 ## Opting In

--- a/terraform/services/ecr-cleanup/lambda_src/dry_run.py
+++ b/terraform/services/ecr-cleanup/lambda_src/dry_run.py
@@ -1,0 +1,34 @@
+"""
+Script for testing config changes locally and preview images that would be deleted. Not used for production code.
+Useful for previewing cleanup behavior before updating repo_config in main.tf
+"""
+
+import json
+from argparse import ArgumentParser
+
+from lambda_function import get_images_to_delete
+
+
+def run(config_path):
+    """
+    Prints tags of (or digest of untagged) images that would be deleted for each repo in config.
+    """
+    with open(config_path, encoding='utf-8') as f:
+        repo_config = json.load(f)
+
+    for repo_name, deleteable in get_images_to_delete(repo_config).items():
+        print(f'{repo_name} images to delete')
+        print('============================================')
+        if len(deleteable):
+            for image in deleteable:
+                print(f'  {image.tags or image.digest}')
+        else:
+            print(f'No images eligible for deletion for {repo_name}')
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='Prints tags of images that would be deleted')
+    parser.add_argument('--config-path', default='dry_run_config.json',
+                        help='path to repo config JSON file (default: dry_run_config.json)')
+    args = parser.parse_args()
+    run(args.config_path)

--- a/terraform/services/ecr-cleanup/lambda_src/dry_run.py
+++ b/terraform/services/ecr-cleanup/lambda_src/dry_run.py
@@ -1,5 +1,6 @@
 """
-Script for testing config changes locally and preview images that would be deleted. Not used for production code.
+Not used for production code.
+Script for testing config changes locally and preview images that would be deleted.
 Useful for previewing cleanup behavior before updating repo_config in main.tf
 """
 

--- a/terraform/services/ecr-cleanup/lambda_src/dry_run_config.json
+++ b/terraform/services/ecr-cleanup/lambda_src/dry_run_config.json
@@ -1,0 +1,10 @@
+{
+    "dpc-api": {
+        "opt_in": true,
+        "strategies": [
+            ["count_image", "rls-r", 5],
+            ["days_older_than", "", 14],
+            ["days_older_than", null, 14]
+        ]
+    }
+}

--- a/terraform/services/ecr-cleanup/lambda_src/lambda_function.py
+++ b/terraform/services/ecr-cleanup/lambda_src/lambda_function.py
@@ -15,7 +15,6 @@ from strategies import DELETE, PROTECT, STRATEGIES
 
 AWS_BATCH_SIZE = 100
 
-ssm_client = boto3.client('ssm')
 ecs_client = boto3.client('ecs')
 ecr_client = boto3.client('ecr')
 
@@ -112,7 +111,7 @@ def get_images_to_delete(repo_config) -> dict[str, list[Image]]:
         protected_refs = get_protected_image_refs(ecs_client)
     except ClientError as e:
         log({'msg': f'Unable to retrieve protected_refs: {e}'})
-        return []
+        return {}
 
     log({'msg': 'Built protected image set from running ECS tasks',
          'repos': list(protected_refs)})
@@ -128,19 +127,6 @@ def get_images_to_delete(repo_config) -> dict[str, list[Image]]:
             log({'msg': f'Error retrieving images from repo {repo_name}: {e}',
                  'repo': repo_name})
     return to_delete
-
-def get_repo_list(client, ssm_param_name):
-    """
-    Read an SSM SecureString parameter and return a list of ECR repository names.
-    Note: this uses SecureString to maintain compatibility with the existing SOPS mechanism.
-    """
-    try:
-        response = client.get_parameter(Name=ssm_param_name, WithDecryption=True)
-        value = response['Parameter']['Value']
-    except ClientError as e:
-        value = "[]"
-        log({'msg': f'Failed to retrieve parameter {ssm_param_name}: {e}'})
-    return json.loads(value)
 
 
 def get_protected_image_refs(client):
@@ -197,16 +183,13 @@ def log_images_for_deletion(repo, images):
 def lambda_handler(_, __):
     """
     Main entry point for lambda function.
-    Reads configured repos from SSM, which are opted in for lambda to clean up.
+    Reads configured repos from the REPO_CONFIG environment variable.
     Reviews active ECS task definitions, then deletes eligible images that
     are old enough and no longer running.
     For repos associated with the app but not opted in, logs images that would
     be deleted without taking action.
     """
-    env = os.environ['ENV']
-    ssm_param = f"/{os.environ['APP']}/{env}/ecr-cleanup/repos"
-
-    repo_config: dict[str, list[str]] = json.loads(get_repo_list(ssm_client, ssm_param))[env]
+    repo_config: dict[str, dict] = json.loads(os.environ['REPO_CONFIG'])
 
     for repo_name, to_delete in get_images_to_delete(repo_config).items():
         if repo_config[repo_name]['opt_in']:
@@ -224,26 +207,31 @@ def lambda_handler(_, __):
     })
 
 def run(args):
-    """ Prints tags of (or digest of untagged) images that would be deleted. """
-    repo = args.repo
-    ssm_param = f"/{args.app}/{args.env}/ecr-cleanup/repos"
-
-    repo_config: dict[str, list[str]] = json.loads(get_repo_list(ssm_client, ssm_param))[args.env]
-    if repo == 'all':
-        to_delete = get_images_to_delete(repo_config)
-    elif repo in repo_config:
-        to_delete = get_images_to_delete({repo: repo_config[repo]})
-    else:
-        print(f'{repo} not configured')
-        sys.exit(1)
-    for repo_name, deleteable in to_delete.items():
+    """
+    Prints tags of (or digest of untagged) images that would be deleted for a given repo.
+    Assumes dpc conventions for strategies used.
+    Forces opt_in=True so deletion candidates are shown regardless of opt-in state.
+    """
+    fake_repo_config = {
+        args.repo: {
+            "opt_in": True,
+            "strategies": [
+                ["count_image","rls-r",5],
+                ["days_older_than","",14],
+                ["days_older_than",None,14]
+            ]
+        }
+    }
+    for repo_name, deleteable in get_images_to_delete(fake_repo_config).items():
         print(repo_name)
-        for image in deleteable:
-            print(f'  {image.tags or image.digest}')
+        if len(deleteable):
+            for image in deleteable:
+                print(f'  {image.tags or image.digest}')
+        else:
+            print(f'No images eligible for deletion for {repo_name}')
+
 
 if __name__ == '__main__':
     parser = ArgumentParser(description='Prints tags of images that would be deleted')
-    parser.add_argument('repo', help='repository to analyze')
-    parser.add_argument('app', help='application to check')
-    parser.add_argument('env', choices=['test', 'prod',], help='environment to check')
+    parser.add_argument('repo', help='repository name to analyze')
     run(parser.parse_args())

--- a/terraform/services/ecr-cleanup/lambda_src/lambda_function.py
+++ b/terraform/services/ecr-cleanup/lambda_src/lambda_function.py
@@ -2,7 +2,6 @@
 Cleans up old ECR images while protecting images referenced by currently running ECS tasks.
 """
 
-from argparse import ArgumentParser
 from datetime import datetime, timezone
 import json
 import os
@@ -204,33 +203,3 @@ def lambda_handler(_, __):
         'app': os.environ['APP'],
         'env': os.environ['ENV'],
     })
-
-def run(args):
-    """
-    Prints tags of (or digest of untagged) images that would be deleted for a given repo.
-    Assumes dpc conventions for strategies used.
-    Forces opt_in=True so deletion candidates are shown regardless of opt-in state.
-    """
-    fake_repo_config = {
-        args.repo: {
-            "opt_in": True,
-            "strategies": [
-                ["count_image","rls-r",5],
-                ["days_older_than","",14],
-                ["days_older_than",None,14]
-            ]
-        }
-    }
-    for repo_name, deleteable in get_images_to_delete(fake_repo_config).items():
-        print(repo_name)
-        if len(deleteable):
-            for image in deleteable:
-                print(f'  {image.tags or image.digest}')
-        else:
-            print(f'No images eligible for deletion for {repo_name}')
-
-
-if __name__ == '__main__':
-    parser = ArgumentParser(description='Prints tags of images that would be deleted')
-    parser.add_argument('repo', help='repository name to analyze')
-    run(parser.parse_args())

--- a/terraform/services/ecr-cleanup/lambda_src/lambda_function.py
+++ b/terraform/services/ecr-cleanup/lambda_src/lambda_function.py
@@ -6,7 +6,6 @@ from argparse import ArgumentParser
 from datetime import datetime, timezone
 import json
 import os
-import sys
 
 import boto3
 from botocore.exceptions import ClientError

--- a/terraform/services/ecr-cleanup/lambda_src/lambda_function.py
+++ b/terraform/services/ecr-cleanup/lambda_src/lambda_function.py
@@ -206,7 +206,7 @@ def lambda_handler(_, __):
     env = os.environ['ENV']
     ssm_param = f"/{os.environ['APP']}/{env}/ecr-cleanup/repos"
 
-    repo_config = get_repo_list(ssm_client, ssm_param)[env]
+    repo_config: dict[str, list[str]] = json.loads(get_repo_list(ssm_client, ssm_param))[env]
 
     for repo_name, to_delete in get_images_to_delete(repo_config).items():
         if repo_config[repo_name]['opt_in']:
@@ -228,7 +228,7 @@ def run(args):
     repo = args.repo
     ssm_param = f"/{args.app}/{args.env}/ecr-cleanup/repos"
 
-    repo_config = get_repo_list(ssm_client, ssm_param)[args.env]
+    repo_config: dict[str, list[str]] = json.loads(get_repo_list(ssm_client, ssm_param))[args.env]
     if repo == 'all':
         to_delete = get_images_to_delete(repo_config)
     elif repo in repo_config:

--- a/terraform/services/ecr-cleanup/lambda_src/test_lambda_function.py
+++ b/terraform/services/ecr-cleanup/lambda_src/test_lambda_function.py
@@ -312,7 +312,7 @@ def _setup_handler_mocks(  # pylint: disable=too-many-arguments,too-many-positio
             'tasks': [{'containers': [{'image': img}]} for img in task_images]
         }
 
-    def ecr_paginator_side_effect(operation):
+    def ecr_paginator_side_effect(_):
         pager = MagicMock()
         pager.paginate.return_value = iter([{'imageDetails': ecr_images or []}])
         return pager
@@ -330,7 +330,8 @@ def test_lambda_handler_deletes_old_unprotected_images(mock_boto3_clients):
         ecr_images=[old_image, new_image],
         repo_configs=repo_configs
     )
-    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}):
+    environment_mocks = {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}
+    with patch.dict(os.environ, environment_mocks):
         lambda_function.lambda_handler({}, None)
     mock_ecr.batch_delete_image.assert_called_once_with(
         repositoryName='some-repo',
@@ -354,7 +355,8 @@ def test_lambda_handler_logs_completion_message(mock_boto3_clients, capfd):
         ecr_images=[old_image],
         repo_configs=repo_configs,
     )
-    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}):
+    environment_mocks = {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}
+    with patch.dict(os.environ, environment_mocks):
         lambda_function.lambda_handler({}, None)
     final_log_message = json.loads(capfd.readouterr().out.strip().splitlines()[-1])
 
@@ -398,7 +400,8 @@ def test_lambda_handler_protects_images_in_running_tasks(mock_boto3_clients):
         ecr_images=[old_image],
         repo_configs=repo_configs,
     )
-    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}):
+    environment_mocks = {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}
+    with patch.dict(os.environ, environment_mocks):
         lambda_function.lambda_handler({}, None)
     mock_ecr.batch_delete_image.assert_not_called()
 

--- a/terraform/services/ecr-cleanup/lambda_src/test_lambda_function.py
+++ b/terraform/services/ecr-cleanup/lambda_src/test_lambda_function.py
@@ -405,10 +405,6 @@ def test_get_protected_image_refs_logs_describe_tasks_failures(capfd):
         'tasks': [],
         'failures': [task_failure]
     }
-    mock_ecs.describe_tasks.return_value = {
-        'tasks': [],
-        'failures': [task_failure]
-    }
 
     lambda_function.get_protected_image_refs(mock_ecs)
     final_log_message = json.loads(capfd.readouterr().out.strip().splitlines()[-1])

--- a/terraform/services/ecr-cleanup/lambda_src/test_lambda_function.py
+++ b/terraform/services/ecr-cleanup/lambda_src/test_lambda_function.py
@@ -249,25 +249,6 @@ def test_delete_images_empty_list():
     lambda_function.delete_images(mock_ecr, 'some-repo', [])
     mock_ecr.batch_delete_image.assert_not_called()
 
-def test_get_repo_list():
-    """SSM parameter value is parsed as a JSON list of repo names."""
-    mock_ssm = MagicMock()
-    mock_ssm.get_parameter.return_value = {'Parameter': {'Value': '["some-repo", "another-repo"]'}}
-    assert lambda_function.get_repo_list(mock_ssm, '/test/param') == ['some-repo', 'another-repo']
-    mock_ssm.get_parameter.assert_called_once_with(Name='/test/param', WithDecryption=True)
-
-def test_get_repo_list_parameter_not_found():
-    """Returns an empty list when the SSM parameter does not exist."""
-    mock_ssm = MagicMock()
-    failed_to_find_message = {
-        "Error": {
-            "Code": "ParameterNotFound",
-            "Message": "Parameter not found",
-        }
-    }
-    mock_ssm.get_parameter.side_effect = ClientError(failed_to_find_message, "get_parameter")
-    assert lambda_function.get_repo_list(mock_ssm, '/param/not/found') == []
-
 def _make_ecs_mock(cluster_arns, task_arns, container_images):
     """Creates a mock ECS client returning the given clusters, tasks, and container images."""
     mock_ecs = MagicMock()
@@ -306,20 +287,16 @@ def test_get_protected_image_refs_on_error():
 @pytest.fixture(autouse=True)
 def mock_boto3_clients():
     """Patches the module-level boto3 clients used by the lambda handler."""
-    with patch('lambda_function.ssm_client') as mock_ssm, \
-         patch('lambda_function.ecs_client') as mock_ecs, \
+    with patch('lambda_function.ecs_client') as mock_ecs, \
          patch('lambda_function.ecr_client') as mock_ecr:
-        yield mock_ssm, mock_ecs, mock_ecr
+        yield mock_ecs, mock_ecr
 
 def _setup_handler_mocks(  # pylint: disable=too-many-arguments,too-many-positional-arguments
-        mock_ssm, mock_ecs, mock_ecr, repo_configs=None,
+        mock_ecs, mock_ecr, repo_configs=None,
         cluster_arns=None, task_arns=None, task_images=None, ecr_images=None):
-    """Configures SSM, ECS, and ECR client mocks for lambda_handler integration tests."""
+    """Configures ECS and ECR client mocks for lambda_handler integration tests."""
     if repo_configs is None:
-        repo_configs = ['some-repo']
-    mock_ssm.get_parameter.return_value = {
-        'Parameter': {'Value': json.dumps(repo_configs)}
-    }
+        repo_configs = {}
 
     def ecs_paginator_side_effect(operation):
         pager = MagicMock()
@@ -335,30 +312,25 @@ def _setup_handler_mocks(  # pylint: disable=too-many-arguments,too-many-positio
             'tasks': [{'containers': [{'image': img}]} for img in task_images]
         }
 
-    repos_page = [{'repositoryName': r} for r in repo_configs]
-
     def ecr_paginator_side_effect(operation):
         pager = MagicMock()
-        if operation == 'describe_repositories':
-            pager.paginate.return_value = iter([{'repositories': repos_page}])
-        else:
-            pager.paginate.return_value = iter([{'imageDetails': ecr_images or []}])
+        pager.paginate.return_value = iter([{'imageDetails': ecr_images or []}])
         return pager
 
     mock_ecr.get_paginator.side_effect = ecr_paginator_side_effect
 
 def test_lambda_handler_deletes_old_unprotected_images(mock_boto3_clients):
     """ Old image is deleted; recent images are kept."""
-    mock_ssm, mock_ecs, mock_ecr = mock_boto3_clients
+    mock_ecs, mock_ecr = mock_boto3_clients
     old_image = make_image('sha256:old', ['unprotected-tag'], EXPIRED_DATETIME).data
     new_image = make_image('sha256:old', ['unprotected-tag'], datetime.now(timezone.utc)).data
+    repo_configs = {'some-repo': {'strategies': (('days_older_than', '', 14,),), 'opt_in': True}}
     _setup_handler_mocks(
-        mock_ssm, mock_ecs, mock_ecr,
+        mock_ecs, mock_ecr,
         ecr_images=[old_image, new_image],
-        repo_configs={ 'test': {'some-repo': { 'strategies': (('days_older_than', '', 14,),),
-                                               'opt_in': True } } }
+        repo_configs=repo_configs
     )
-    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test'}):
+    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}):
         lambda_function.lambda_handler({}, None)
     mock_ecr.batch_delete_image.assert_called_once_with(
         repositoryName='some-repo',
@@ -371,18 +343,18 @@ def test_lambda_handler_logs_completion_message(mock_boto3_clients, capfd):
     Ensures successful execution of lambda_handler() will create log statement
     indicating completion of ECR-cleanup. This is used for monitoring in Splunk.
     """
-    mock_ssm, mock_ecs, mock_ecr = mock_boto3_clients
+    mock_ecs, mock_ecr = mock_boto3_clients
     old_image = make_image('sha256:old', ['old-tag'], EXPIRED_DATETIME).data
+    repo_configs = {'some-repo': {'strategies': (('days_older_than', '', 14,),), 'opt_in': True}}
     _setup_handler_mocks(
-        mock_ssm, mock_ecs, mock_ecr,
+        mock_ecs, mock_ecr,
         cluster_arns=[CLUSTER_ARN],
         task_arns=[f'{CLUSTER_ARN}/task1'],
         task_images=[f'{ECR_REGISTRY}/some-repo:protected-tag'],
         ecr_images=[old_image],
-        repo_configs={ 'test': {'some-repo': { 'strategies': (('days_older_than', '', 14,),),
-                                               'opt_in': True } } }
+        repo_configs=repo_configs,
     )
-    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test'}):
+    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}):
         lambda_function.lambda_handler({}, None)
     final_log_message = json.loads(capfd.readouterr().out.strip().splitlines()[-1])
 
@@ -415,18 +387,18 @@ def test_get_protected_image_refs_logs_describe_tasks_failures(capfd):
 
 def test_lambda_handler_protects_images_in_running_tasks(mock_boto3_clients):
     """Image referenced by a running ECS task is never deleted even if old."""
-    mock_ssm, mock_ecs, mock_ecr = mock_boto3_clients
+    mock_ecs, mock_ecr = mock_boto3_clients
     old_image = make_image('sha256:old', ['protected-tag'], EXPIRED_DATETIME).data
+    repo_configs = {'some-repo': {'strategies': (('days_older_than', '', 14,),), 'opt_in': True}}
     _setup_handler_mocks(
-        mock_ssm, mock_ecs, mock_ecr,
+        mock_ecs, mock_ecr,
         cluster_arns=[CLUSTER_ARN],
         task_arns=[f'{CLUSTER_ARN}/task1'],
         task_images=[f'{ECR_REGISTRY}/some-repo:protected-tag'],
         ecr_images=[old_image],
-        repo_configs={ 'test': {'some-repo': { 'strategies': (('days_older_than', '', 14,),),
-                                               'opt_in': True } } }
+        repo_configs=repo_configs,
     )
-    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test'}):
+    with patch.dict(os.environ, {'APP': 'cdap', 'ENV': 'test', 'REPO_CONFIG': json.dumps(repo_configs)}):
         lambda_function.lambda_handler({}, None)
     mock_ecr.batch_delete_image.assert_not_called()
 

--- a/terraform/services/ecr-cleanup/main.tf
+++ b/terraform/services/ecr-cleanup/main.tf
@@ -5,7 +5,7 @@ locals {
     test = ["dpc-web"]
     prod = ["dpc-web"]
   }
-  repo_config = jsonencode({
+  repo_config = {
     "test" : {
       "dpc-web" : {
         "strategies" : [
@@ -24,7 +24,7 @@ locals {
         ],
       "opt_in" : false }
     }
-  })
+  }
 }
 
 data "aws_ecr_repository" "repos" {
@@ -63,29 +63,11 @@ data "aws_iam_policy_document" "ecs_access_policy" {
   }
 }
 
-data "aws_iam_policy_document" "ssm_access_policy" {
-  statement {
-    sid     = "SSMAccess"
-    actions = ["ssm:GetParameter"]
-    resources = [
-      aws_ssm_parameter.repo_list.arn
-    ]
-  }
-}
-
 data "aws_iam_policy_document" "ecr_cleanup" {
   source_policy_documents = [
     data.aws_iam_policy_document.ecr_access_policy.json,
     data.aws_iam_policy_document.ecs_access_policy.json,
-    data.aws_iam_policy_document.ssm_access_policy.json,
   ]
-}
-
-resource "aws_ssm_parameter" "repo_list" {
-  name        = "/${var.app}/${var.env}/ecr-cleanup/repos"
-  type        = "SecureString"
-  description = "Comma-separated list of ECR repository names to clean up"
-  value       = jsonencode(local.repo_config)
 }
 
 data "archive_file" "ecr_cleanup" {
@@ -122,8 +104,9 @@ module "ecr_cleanup_function" {
   }
 
   environment_variables = {
-    APP = var.app
-    ENV = var.env
+    APP         = var.app
+    ENV         = var.env
+    REPO_CONFIG = jsonencode(local.repo_config[var.env])
   }
 
 }

--- a/terraform/services/ecr-cleanup/main.tf
+++ b/terraform/services/ecr-cleanup/main.tf
@@ -90,8 +90,17 @@ resource "aws_ssm_parameter" "repo_list" {
 
 data "archive_file" "ecr_cleanup" {
   type        = "zip"
-  source_file = "${path.module}/lambda_src/lambda_function.py"
   output_path = "${path.module}/function.zip"
+
+  source {
+    content  = file("${path.module}/lambda_src/lambda_function.py")
+    filename = "lambda_function.py"
+  }
+
+  source {
+    content  = file("${path.module}/lambda_src/strategies.py")
+    filename = "strategies.py"
+  }
 }
 
 module "ecr_cleanup_function" {


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5291](https://jira.cms.gov/browse/DPC-5291), [DPC-5310](https://jira.cms.gov/browse/DPC-5310)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
  - remove SSM parameter for repository opt-in configuration
    - passed directly from terraform to python via environment variable `REPO_CONFIG` now
  - Fix `ImportModuleError` - terraform now includes `strategies.py` in the deployed code

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - Originally, this PR began as a bugfix for [DPC-5310](https://jira.cms.gov/browse/DPC-5310).
   - Originally the python code for this lambda was in a single source file: `lambda_function.py`. After refactoring to improve readability, the terraform still needed to be updated to include `strategies.py` in the uploaded zip for the lambda function.
   - After deploying a fix to include the missing `strategies.py` file in the _test_ env, the lambda was showing a new Trackeback:
```
[ERROR] TypeError: string indices must be integers, not 'str'
Traceback (most recent call last):
  File "/var/task/lambda_function.py", line 209, in lambda_handler
    repo_config = get_repo_list(ssm_client, ssm_param)[env]
```
 - There was already a ticket in the backlog to remove `get_repo_list()` -  [DPC-5291](https://jira.cms.gov/browse/DPC-5291), so doing it at the same time was the most straightforward path
 - Notes on `get_repo_list()`:
   - The structure of configuration used is no longer a list. Python code needs to be updated to parse this correctly.
   - Contents for this parameter were also being json encoded twice, resulting in the `TypeError`
   - Screenshot of SSM parameter for non-prod account:
     - <img width="300" alt="Screenshot 2026-04-03 at 10 10 36 AM" src="https://github.com/user-attachments/assets/6ed4c742-de5a-4cfe-ba71-7ed4dbc23c50" />




## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

 - pylint and pytest pass locally
 - Lambda executes without errors in the `test` environment:
<img width="901" height="556" alt="Screenshot 2026-04-03 at 10 02 37 AM" src="https://github.com/user-attachments/assets/6bb3c846-bd8b-4931-b715-b51687df22ee" />
