### PR TITLE
[DPC-5295] specify arm64 for function module, update ecr-cleanup to use arm64

### DIFF
--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -233,6 +233,7 @@ resource "aws_lambda_function" "this" {
   timeout           = var.timeout
   memory_size       = var.memory_size
   layers            = var.layer_arns
+  architectures = ["arm64"] # Graviton support for better price/performance
 
   tracing_config {
     mode = "Active"

--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -233,7 +233,7 @@ resource "aws_lambda_function" "this" {
   timeout           = var.timeout
   memory_size       = var.memory_size
   layers            = var.layer_arns
-  architectures = ["arm64"] # Graviton support for better price/performance
+  architectures     = ["arm64"]
 
   tracing_config {
     mode = "Active"

--- a/terraform/services/ecr-cleanup/main.tf
+++ b/terraform/services/ecr-cleanup/main.tf
@@ -86,7 +86,7 @@ data "archive_file" "ecr_cleanup" {
 }
 
 module "ecr_cleanup_function" {
-  source = "github.com/CMSgov/cdap/terraform/modules/function?ref=f4c14d47cc20e7f6de9112d7155af1213c9bca5a"
+  source = "github.com/CMSgov/cdap/terraform/modules/function?ref=3bcf9b7df59a7e982185b67f6a924e9fe0d037e5"
 
   app = var.app
   env = var.env

--- a/terraform/services/ecr-cleanup/main.tf
+++ b/terraform/services/ecr-cleanup/main.tf
@@ -86,7 +86,7 @@ data "archive_file" "ecr_cleanup" {
 }
 
 module "ecr_cleanup_function" {
-  source = "github.com/CMSgov/cdap/terraform/modules/function?ref=3bcf9b7df59a7e982185b67f6a924e9fe0d037e5"
+  source = "github.com/CMSgov/cdap/terraform/modules/function?ref=d3b3b7a89cff7027aabd2e193df29e549937ecc3"
 
   app = var.app
   env = var.env


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5295](https://jira.cms.gov/browse/DPC-5295)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - update function module to specify arm64 architecture
 - update function module hash to latest for ecr-cleanup-lambda in order to make use of this change

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - This is part of an ongoing migration to move from x86 -> arm64

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - Did a fresh deploy from `main` to cdap-test-ecr-cleaup and verified architecture was x86.
 - Then I did a deployment with changes from this PR and verified architecture was arm64
 <img width="1579" height="529" alt="Screenshot 2026-04-09 at 11 29 01 AM" src="https://github.com/user-attachments/assets/928ad344-9bf3-42bd-b925-5652643f6387" />
 
 
 
 - verified lambda still runs successfully
<img width="1308" height="634" alt="Screenshot 2026-04-09 at 11 33 16 AM" src="https://github.com/user-attachments/assets/d9140525-2278-4ef5-8a0b-fd73c2e7a229" />
