### PR TITLE
[DPC-5295] move "arm64" to a variable so services can incrementally opt in

### DIFF
--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -233,7 +233,7 @@ resource "aws_lambda_function" "this" {
   timeout           = var.timeout
   memory_size       = var.memory_size
   layers            = var.layer_arns
-  architectures     = ["arm64"]
+  architectures     = [var.architecture]
 
   tracing_config {
     mode = "Active"

--- a/terraform/modules/function/variables.tf
+++ b/terraform/modules/function/variables.tf
@@ -32,6 +32,16 @@ variable "handler" {
   default     = "function_handler"
 }
 
+variable "architecture" {
+  description = ""
+  type        = string
+  default     = "x86_64"
+  validation {
+    condition     = contains(["x86_64", "arm64"], var.architecture)
+    error_message = "Valid value for architecture is x86_64 or arm64"
+  }
+}
+
 variable "runtime" {
   description = "Lambda function runtime"
   type        = string


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5295](https://jira.cms.gov/browse/DPC-5295)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - moved architecture to function module's `variable.tf`
   - this means teams can incrementally opt into the ARM64 changes (see example in context below) 

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - DPC is the first of partner API teams to migrate to arm64 architecture.
  - This change to the function module needs to happen before services that call it update the hash. The merge commit of the pull request will have the hash that should be used. See example here: https://github.com/CMSgov/cdap/pull/441
  - Previously I hardcoded `architectures = ["arm64"]`
    - Other teams share this function module and it needs to be backwards compatible during the transition period
    - This works for python code in this repository, but doesn't work for code that is compiled for x86
    - DPC will update CI to compile .go code for arm64 
      - associated workflows live here: [dpc-app/.github/workflows](https://github.com/CMSgov/dpc-app/tree/main/.github/workflows)
       - workflow updates will be accompanied by changes in cdap repository to use arm64 for **ONLY** dpc
       - see example for api-waf-sync below:
  ```
module "api_waf_sync_function" {
    source = "github.com/CMSgov/cdap/terraform/modules/function?ref=<new_hash>"

    app          = var.app
    env          = var.env
    architecture = var.app == "dpc" ? "arm64" : "x86_64"
    ...
}
  ```
  

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
#### Verified that specifying latest function module hash without architecture variables keeps things on x86
 - <img width="774" height="401" alt="Screenshot 2026-04-13 at 3 49 04 PM" src="https://github.com/user-attachments/assets/fc3563dd-8d16-4cd7-8359-0a724ac65a5e" />

 #### Verified arm64 code runs when architecture is specified 
 - compiled DPC api waf sync from arm64 architecture [HERE](https://github.com/CMSgov/dpc-app/actions/runs/24368539258)
 - deployed terraform with architecture variable set to `"arm64"` in the `test` environment
 - manually invoked lambda and verified it executes successfully
 ```
aws lambda invoke --function-name dpc-test-api-waf-sync --region us-east-1 response.json
```
<img width="1370" height="651" alt="Screenshot 2026-04-13 at 3 27 00 PM" src="https://github.com/user-attachments/assets/d22b414b-db43-4607-bfad-8b055586eff7" />
<img width="1566" height="901" alt="Screenshot 2026-04-13 at 3 24 51 PM" src="https://github.com/user-attachments/assets/cf042215-8a1b-4542-ad50-db25830d4ea9" />
