### PR TITLE
DPC-5323 Updating bucket module with variable default encryption key

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -68,8 +68,12 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
     bucket_key_enabled = true
 
     apply_server_side_encryption_by_default {
-      kms_master_key_id = data.aws_kms_alias.kms_key.target_key_arn
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "aws:kms"
+      kms_master_key_id = (
+        var.default_encryption_key_arn == null ?
+        data.aws_kms_alias.kms_key.target_key_arn :
+        var.default_encryption_key_arn
+      )
     }
   }
 }

--- a/terraform/modules/bucket/variables.tf
+++ b/terraform/modules/bucket/variables.tf
@@ -13,6 +13,12 @@ variable "app" {
   }
 }
 
+variable "default_encryption_key_arn" {
+  default     = null
+  description = "The ARN of the default S3 bucket encryption key"
+  type        = string
+}
+
 variable "env" {
   description = "The application environment (dev, test, sandbox, prod, mgmt)"
   type        = string


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5323

## 🛠 Changes

This PR adds an optional `default_encryption_key_arn` variable to allow for overriding the default `<app>.<env>` key.

## ℹ️ Context

- The DPC QuickSight export bucket is managed by the CDAP bucket module, and as a result the default encryption key is set to the shared `<app>.<env>` key.
- The shared `<app>.<env>` keys are not configured to allow cross account access from the DASG account QuickSight service by design, since the decision was made some time ago to use a dedicated DASG Insights shared key instead (i.e. `aurora_export`).
- This has not been an issue until now since the `aws_s3` extension running on the postgres instances of all three applications ignores the default encryption key and must be overridden at the extension level with the shared `aurora_export` key .
- DPC has implemented a Lambda that optimizes DB query times and handles the CSV file writes that are ultimately to be ingested as QuickSight data sources, but this Lambda utilizes the default `app-env` encryption key (unlike the postgres `aws_s3` extension) so the DASG account QuickSight service cannot read these files.
- This PR allows for the default encryption key to be overridden for edge cases such as this.

## 🧪 Validation

<details>
<summary>Tofu Apply Output (DPC-PROD)</summary>

```
  # module.export_bucket.aws_s3_bucket_server_side_encryption_configuration.this will be updated in-place
  ~ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
        id     = "dpc-prod-aurora-export-2025xxxxxxxxxxxxxxxx00000001"
        # (2 unchanged attributes hidden)

      - rule {
          - blocked_encryption_types = [
              - "NONE",
            ] -> null
          - bucket_key_enabled       = true -> null

          - apply_server_side_encryption_by_default {
              - kms_master_key_id = "arn:aws:kms:us-east-1:xxxxxxxxxxxx:key/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxed" -> null
              - sse_algorithm     = "aws:kms:dsse" -> null
            }
        }
      + rule {
          + blocked_encryption_types = (known after apply)
          + bucket_key_enabled       = true

          + apply_server_side_encryption_by_default {
              + kms_master_key_id = "arn:aws:kms:us-east-1:xxxxxxxxxxxx:key/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx4b"
              + sse_algorithm     = "aws:kms"
            }
        }
    }
```
</details>