### PR TITLE
PLT-1662 Run log retention workflow with codebuild default python 

### DIFF
--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -106,7 +106,36 @@ jobs:
           echo "**Download the \`retention-plan\` artifact from the bottom of this page before approving.**" >> "$GITHUB_STEP_SUMMARY"
           
 
-  # ── JOB 2: APPROVE (manual gate) ───────────────────────────────────────────
+  # ── JOB 2 & 3: NOTIFY & APPROVE (manual gate) ───────────────────────────────────────────
+  notify:
+    name: "Pending Approval – Review Plan Details Here"
+    needs: plan
+    if: needs.plan.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Post plan summary for reviewer
+        run: |
+          echo "## ⏳ Retention Plan Awaiting Approval"            >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                   >> "$GITHUB_STEP_SUMMARY"
+          echo "| Key | Value |"                                   >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ----- |"                                   >> "$GITHUB_STEP_SUMMARY"
+          echo "| Plan file    | \`${{ needs.plan.outputs.plan_file }}\` |"       >> "$GITHUB_STEP_SUMMARY"
+          echo "| Target env   | \`${{ needs.plan.outputs.target_env }}\` |"      >> "$GITHUB_STEP_SUMMARY"
+          echo "| Generated at | \`${{ needs.plan.outputs.generated_at }}\` |"   >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commands     | **${{ needs.plan.outputs.command_count }}** |"  >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                   >> "$GITHUB_STEP_SUMMARY"
+          echo "---"                                               >> "$GITHUB_STEP_SUMMARY"
+          echo "**Scroll and download the \`retention-plan\` artifact before approving.**" >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                   >> "$GITHUB_STEP_SUMMARY"
+          echo " Once reviewed, click **Review deployments** to approve or reject." >> "$GITHUB_STEP_SUMMARY"
+
+          # Also print to console log so it's visible in raw step output
+          echo "Plan file:    ${{ needs.plan.outputs.plan_file }}"
+          echo "Target env:   ${{ needs.plan.outputs.target_env }}"
+          echo "Generated at: ${{ needs.plan.outputs.generated_at }}"
+          echo "Commands:     ${{ needs.plan.outputs.command_count }}"
+
   approve:
     name: "Approve – Review Plan Before Applying"
     needs: plan
@@ -139,6 +168,7 @@ jobs:
           echo "Commands:   ${{ needs.plan.outputs.command_count }}"
           echo "Proceeding to apply retention policy changes."
           
+
 
   # ── JOB 3: APPLY ───────────────────────────────────────────────────────────
   apply:

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -57,7 +57,7 @@ jobs:
             if echo "$INPUT_ENV" | grep -qiE 'prod|sandbox'; then
               echo "runner_env=prod"     >> "$GITHUB_OUTPUT"
             elif echo "$INPUT_ENV" | grep -qiE 'dev|test'; then
-              echo "runner_env=non_prod" >> "$GITHUB_OUTPUT"
+              echo "runner_env=non-prod" >> "$GITHUB_OUTPUT"
             else
               echo "::error::Environment '${INPUT_ENV}' must contain one of: prod, sandbox, dev, test"
               exit 1
@@ -183,12 +183,7 @@ jobs:
     name: "Apply - Execute Retention Policy Updates"
     needs: [plan, approve]
     if: needs.plan.outputs.has_changes == 'true'
-    runs-on: >-
-      codebuild-cdap-${{
-        needs.plan.outputs.runner_env == 'prod'
-        && 'prod'
-        || 'non-prod'
-      }}-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-cdap-${{ needs.plan.outputs.runner_env }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -2,7 +2,7 @@ name: CloudWatch Log Retention Manager
 
 on:
   schedule:
-    - cron: "0 14 * * 1"
+    - cron: "0 14 * * 1" # Every Monday at 14:00 UTC set to always run on prod
   workflow_dispatch:
     inputs:
       retention_days:
@@ -12,7 +12,6 @@ on:
       target_env:
         description: "Target environment string (e.g. ephemeral-prod, happy-test, nice-sandbox, dev)"
         required: true
-        default: "prod"
 
 permissions:
   contents: write

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -23,7 +23,7 @@ env:
   AWS_REGION:     us-east-1
   RETENTION_DAYS: ${{ github.event.inputs.retention_days || '180' }}
   TARGET_ENV:     ${{ github.event.inputs.target_env || 'prod' }}
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.13.12"
 
 jobs:
 

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -20,20 +20,23 @@ permissions:
   id-token: write
 
 env:
-  AWS_REGION:     us-east-1
+  AWS_REGION: us-east-1
   RETENTION_DAYS: ${{ github.event_name == 'schedule' && '180' || github.event.inputs.retention_days || '180' }}
-  TARGET_ENV:     ${{ github.event_name == 'schedule' && 'prod' || github.event.inputs.target_env || 'prod' }}
+  TARGET_ENV: ${{ github.event_name == 'schedule' && 'prod' || github.event.inputs.target_env || 'prod' }}
 
 jobs:
 
-  # ── JOB 1: PLAN ────────────────────────────────────────────────────────────
+  # -- JOB 1: PLAN ------------------------------------------------------------
   plan:
-    name: "Plan – Generate Retention Plan"
+    name: "Plan - Generate Retention Plan"
     runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     outputs:
-      plan_file:   ${{ steps.meta.outputs.plan_file }}
+      plan_file: ${{ steps.meta.outputs.plan_file }}
       has_changes: ${{ steps.meta.outputs.has_changes }}
+      command_count: ${{ steps.meta.outputs.command_count }}
+      target_env: ${{ steps.meta.outputs.target_env }}
+      generated_at: ${{ steps.meta.outputs.generated_at }}
 
     steps:
       - name: Checkout
@@ -58,10 +61,10 @@ jobs:
       - name: Run plan
         working-directory: ${{ github.workspace }}/scripts/set_log_retention
         env:
-          MODE:           plan
-          AWS_REGION:     ${{ vars.AWS_REGION }}
+          MODE: plan
+          AWS_REGION: ${{ vars.AWS_REGION }}
           RETENTION_DAYS: ${{ env.RETENTION_DAYS }}
-          TARGET_ENV:     ${{ env.TARGET_ENV }}
+          TARGET_ENV: ${{ env.TARGET_ENV }}
         run: python3 set_log_retention.py
 
       - name: Collect metadata
@@ -69,27 +72,27 @@ jobs:
         working-directory: ${{ github.workspace }}/scripts/set_log_retention
         run: |
           PLAN_FILE=$(ls retention-plan-*.json 2>/dev/null | head -n 1)
-
+          
           if [ -z "$PLAN_FILE" ]; then
-            echo "Err No retention plan file found in $(pwd)"
+            echo "No retention plan file found in $(pwd)"
             ls -la
             exit 1
           fi
-
+          
           COMMAND_COUNT=$(jq '.commands | length' "$PLAN_FILE")
           GENERATED_AT=$(jq -r '.generated_at' "$PLAN_FILE")
-
+          
           echo "plan_file=${PLAN_FILE}"           >> "$GITHUB_OUTPUT"
           echo "command_count=${COMMAND_COUNT}"   >> "$GITHUB_OUTPUT"
           echo "target_env=${{ env.TARGET_ENV }}" >> "$GITHUB_OUTPUT"
           echo "generated_at=${GENERATED_AT}"     >> "$GITHUB_OUTPUT"
-
+          
           if [ "$COMMAND_COUNT" -gt 0 ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
-
+          
           echo "### Retention Plan"                               >> "$GITHUB_STEP_SUMMARY"
           echo "| Key | Value |"                                  >> "$GITHUB_STEP_SUMMARY"
           echo "| --- | ----- |"                                  >> "$GITHUB_STEP_SUMMARY"
@@ -103,12 +106,18 @@ jobs:
           echo "\`\`\`"                                            >> "$GITHUB_STEP_SUMMARY"
           echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
           echo "---"                                               >> "$GITHUB_STEP_SUMMARY"
-          echo "**Download the \`retention-plan\` artifact from the bottom of this page before approving.**" >> "$GITHUB_STEP_SUMMARY"
-          
+          echo "Download the \`retention-plan\` artifact from the bottom of this page before approving." >> "$GITHUB_STEP_SUMMARY"
 
-  # ── JOB 2 & 3: NOTIFY & APPROVE (manual gate) ───────────────────────────────────────────
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: retention-plan
+          path: ${{ github.workspace }}/scripts/set_log_retention/retention-plan-*.json
+          retention-days: 7
+
+  # -- JOB 2: NOTIFY ----------------------------------------------------------
   notify:
-    name: "Pending Approval – Review Plan Details Here"
+    name: "Pending Approval - Review Plan Details Here"
     needs: plan
     if: needs.plan.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
@@ -116,64 +125,40 @@ jobs:
     steps:
       - name: Post plan summary for reviewer
         run: |
-          echo "## ⏳ Retention Plan Awaiting Approval"            >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                   >> "$GITHUB_STEP_SUMMARY"
-          echo "| Key | Value |"                                   >> "$GITHUB_STEP_SUMMARY"
-          echo "| --- | ----- |"                                   >> "$GITHUB_STEP_SUMMARY"
-          echo "| Plan file    | \`${{ needs.plan.outputs.plan_file }}\` |"       >> "$GITHUB_STEP_SUMMARY"
-          echo "| Target env   | \`${{ needs.plan.outputs.target_env }}\` |"      >> "$GITHUB_STEP_SUMMARY"
-          echo "| Generated at | \`${{ needs.plan.outputs.generated_at }}\` |"   >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commands     | **${{ needs.plan.outputs.command_count }}** |"  >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                   >> "$GITHUB_STEP_SUMMARY"
-          echo "---"                                               >> "$GITHUB_STEP_SUMMARY"
-          echo "**Scroll and download the \`retention-plan\` artifact before approving.**" >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                   >> "$GITHUB_STEP_SUMMARY"
-          echo " Once reviewed, click **Review deployments** to approve or reject." >> "$GITHUB_STEP_SUMMARY"
+          echo "## Retention Plan Awaiting Approval"                                       >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                                           >> "$GITHUB_STEP_SUMMARY"
+          echo "| Key | Value |"                                                           >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ----- |"                                                           >> "$GITHUB_STEP_SUMMARY"
+          echo "| Plan file    | \`${{ needs.plan.outputs.plan_file }}\` |"                >> "$GITHUB_STEP_SUMMARY"
+          echo "| Target env   | \`${{ needs.plan.outputs.target_env }}\` |"               >> "$GITHUB_STEP_SUMMARY"
+          echo "| Generated at | \`${{ needs.plan.outputs.generated_at }}\` |"            >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commands     | **${{ needs.plan.outputs.command_count }}** |"           >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                                           >> "$GITHUB_STEP_SUMMARY"
+          echo "---"                                                                        >> "$GITHUB_STEP_SUMMARY"
+          echo "Scroll down and download the \`retention-plan\` artifact before approving." >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                                           >> "$GITHUB_STEP_SUMMARY"
+          echo "Once reviewed, click **Review deployments** to approve or reject."         >> "$GITHUB_STEP_SUMMARY"
 
-          # Also print to console log so it's visible in raw step output
-          echo "Plan file:    ${{ needs.plan.outputs.plan_file }}"
-          echo "Target env:   ${{ needs.plan.outputs.target_env }}"
-          echo "Generated at: ${{ needs.plan.outputs.generated_at }}"
-          echo "Commands:     ${{ needs.plan.outputs.command_count }}"
-
+  # -- JOB 3: APPROVE (manual gate) -------------------------------------------
   approve:
-    name: "Approve – Review Plan Before Applying"
-    needs: plan
+    name: "Approve - Review Plan Before Applying"
+    needs: [ plan, notify ]
     if: needs.plan.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     environment: compliance-approval
 
     steps:
-      - name: Display plan summary for review
-        run: |
-          echo "## 📋 Retention Plan Pending Approval"           >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
-          echo "| Key | Value |"                                  >> "$GITHUB_STEP_SUMMARY"
-          echo "| --- | ----- |"                                  >> "$GITHUB_STEP_SUMMARY"
-          echo "| Plan file | \`${{ needs.plan.outputs.plan_file }}\` |"       >> "$GITHUB_STEP_SUMMARY"
-          echo "| Target env | \`${{ needs.plan.outputs.target_env }}\` |"     >> "$GITHUB_STEP_SUMMARY"
-          echo "| Generated at | \`${{ needs.plan.outputs.generated_at }}\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commands to apply | **${{ needs.plan.outputs.command_count }}** |" >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
-          echo "---"                                               >> "$GITHUB_STEP_SUMMARY"
-          echo " **Download the \`retention-plan\` artifact from the bottom of the run page to review the full command list before approving.**" >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
-          echo " [View full plan job summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> "$GITHUB_STEP_SUMMARY"
-
       - name: Approval confirmed
         run: |
-          echo "Plan reviewed and approved."
+          echo "Plan approved."
           echo "Plan file:  ${{ needs.plan.outputs.plan_file }}"
           echo "Target env: ${{ needs.plan.outputs.target_env }}"
           echo "Commands:   ${{ needs.plan.outputs.command_count }}"
-          echo "Proceeding to apply retention policy changes."
-          
 
-
-  # ── JOB 3: APPLY ───────────────────────────────────────────────────────────
+  # -- JOB 4: APPLY -----------------------------------------------------------
   apply:
-    name: "Apply – Execute Retention Policy Updates"
-    needs: [plan, approve]
+    name: "Apply - Execute Retention Policy Updates"
+    needs: [ plan, approve ]
     if: needs.plan.outputs.has_changes == 'true'
     runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
 
@@ -207,8 +192,8 @@ jobs:
       - name: Apply retention plan
         working-directory: ${{ github.workspace }}/scripts/set_log_retention
         env:
-          MODE:       apply
-          PLAN_FILE:  ${{ steps.find-plan.outputs.plan_file }}
+          MODE: apply
+          PLAN_FILE: ${{ steps.find-plan.outputs.plan_file }}
           AWS_REGION: ${{ vars.AWS_REGION }}
         run: python3 set_log_retention.py
 
@@ -219,3 +204,4 @@ jobs:
           name: retention-apply-report
           path: ${{ github.workspace }}/scripts/set_log_retention/retention-report-*.csv
           retention-days: 30
+

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -2,6 +2,7 @@ name: CloudWatch Log Retention Manager
 
 on:
   schedule:
+    # Every Monday at 10:00 ET (14:00 UTC)
     - cron: "0 14 * * 1"
   workflow_dispatch:
     inputs:
@@ -28,9 +29,6 @@ jobs:
   plan:
     name: "Plan – Generate Retention Plan"
     runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
-    defaults:
-      run:
-        working-directory: scripts/set_cloudwatch_retention
 
     outputs:
       plan_file:   ${{ steps.meta.outputs.plan_file }}
@@ -41,11 +39,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.0
 
       - name: Check available Python
+        working-directory: ${{ github.workspace }}
         run: |
           python3 --version
           which python3
 
       - name: Install dependencies
+        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
         run: python3 -m pip install -r requirements.txt
 
       - name: Configure AWS credentials
@@ -55,6 +55,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Run plan
+        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
         env:
           MODE:           plan
           AWS_REGION:     ${{ vars.AWS_REGION }}
@@ -64,6 +65,7 @@ jobs:
 
       - name: Collect metadata
         id: meta
+        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
         run: |
           PLAN_FILE=$(ls retention-plan-*.json | head -n 1)
           COMMAND_COUNT=$(jq '.commands | length' "$PLAN_FILE")
@@ -93,10 +95,11 @@ jobs:
         with:
           name: retention-plan
           path: |
-            scripts/set_cloudwatch_retention/retention-plan-*.json
-            scripts/set_cloudwatch_retention/retention-report-*.csv
+            ${{ github.workspace }}/scripts/set_cloudwatch_retention/retention-plan-*.json
+            ${{ github.workspace }}/scripts/set_cloudwatch_retention/retention-report-*.csv
           retention-days: 7
 
+  # ── JOB 2: APPROVE (manual gate) ───────────────────────────────────────────
   approve:
     name: "Approve – Review Plan Before Applying"
     needs: plan
@@ -111,20 +114,19 @@ jobs:
           echo "Plan file: ${{ needs.plan.outputs.plan_file }}"
           echo "Proceeding to apply retention policy changes."
 
+  # ── JOB 3: APPLY ───────────────────────────────────────────────────────────
   apply:
     name: "Apply – Execute Retention Policy Updates"
     needs: [plan, approve]
     if: needs.plan.outputs.has_changes == 'true'
     runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
-    defaults:
-      run:
-        working-directory: scripts/set_cloudwatch_retention
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.0
 
       - name: Install dependencies
+        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
         run: python3 -m pip install -r requirements.txt
 
       - name: Configure AWS credentials
@@ -137,15 +139,17 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: retention-plan
-          path: scripts/set_cloudwatch_retention
+          path: ${{ github.workspace }}/scripts/set_cloudwatch_retention
 
       - name: Locate plan file
         id: find-plan
+        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
         run: |
           PLAN_FILE=$(ls retention-plan-*.json | head -n 1)
           echo "plan_file=${PLAN_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Apply retention plan
+        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
         env:
           MODE:       apply
           PLAN_FILE:  ${{ steps.find-plan.outputs.plan_file }}
@@ -157,5 +161,5 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: retention-apply-report
-          path: scripts/set_cloudwatch_retention/retention-report-*.csv
+          path: ${{ github.workspace }}/scripts/set_cloudwatch_retention/retention-report-*.csv
           retention-days: 30

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -67,12 +67,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.0
 
-      - name: Check available Python
-        working-directory: ${{ github.workspace }}
-        run: |
-          python3 --version
-          which python3
-
       - name: Install dependencies
         working-directory: ${{ github.workspace }}/scripts/set_log_retention
         run: python3 -m pip install -r requirements.txt

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -45,7 +45,7 @@ jobs:
           which python3
 
       - name: Install dependencies
-        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
+        working-directory: ${{ github.workspace }}/scripts/set_log_retention
         run: python3 -m pip install -r requirements.txt
 
       - name: Configure AWS credentials
@@ -55,7 +55,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Run plan
-        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
+        working-directory: ${{ github.workspace }}/scripts/set_log_retention
         env:
           MODE:           plan
           AWS_REGION:     ${{ vars.AWS_REGION }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Collect metadata
         id: meta
-        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
+        working-directory: ${{ github.workspace }}/scripts/set_log_retention
         run: |
           PLAN_FILE=$(ls retention-plan-*.json | head -n 1)
           COMMAND_COUNT=$(jq '.commands | length' "$PLAN_FILE")
@@ -95,8 +95,8 @@ jobs:
         with:
           name: retention-plan
           path: |
-            ${{ github.workspace }}/scripts/set_cloudwatch_retention/retention-plan-*.json
-            ${{ github.workspace }}/scripts/set_cloudwatch_retention/retention-report-*.csv
+            ${{ github.workspace }}/scripts/set_log_retention/retention-plan-*.json
+            ${{ github.workspace }}/scripts/set_log_retention/retention-report-*.csv
           retention-days: 7
 
   # ── JOB 2: APPROVE (manual gate) ───────────────────────────────────────────
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.0
 
       - name: Install dependencies
-        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
+        working-directory: ${{ github.workspace }}/scripts/set_log_retention
         run: python3 -m pip install -r requirements.txt
 
       - name: Configure AWS credentials
@@ -139,17 +139,17 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: retention-plan
-          path: ${{ github.workspace }}/scripts/set_cloudwatch_retention
+          path: ${{ github.workspace }}/scripts/set_log_retention
 
       - name: Locate plan file
         id: find-plan
-        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
+        working-directory: ${{ github.workspace }}/scripts/set_log_retention
         run: |
           PLAN_FILE=$(ls retention-plan-*.json | head -n 1)
           echo "plan_file=${PLAN_FILE}" >> "$GITHUB_OUTPUT"
 
       - name: Apply retention plan
-        working-directory: ${{ github.workspace }}/scripts/set_cloudwatch_retention
+        working-directory: ${{ github.workspace }}/scripts/set_log_retention
         env:
           MODE:       apply
           PLAN_FILE:  ${{ steps.find-plan.outputs.plan_file }}
@@ -161,5 +161,5 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: retention-apply-report
-          path: ${{ github.workspace }}/scripts/set_cloudwatch_retention/retention-report-*.csv
+          path: ${{ github.workspace }}/scripts/set_log_retention/retention-report-*.csv
           retention-days: 30

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -102,7 +102,7 @@ jobs:
           PLAN_FILE=$(ls retention-plan-*.json 2>/dev/null | head -n 1)
 
           if [ -z "$PLAN_FILE" ]; then
-            echo "No retention plan file found in $(pwd)"
+            echo "No retention plan file found in $(PWD)"
             ls -la
             exit 1
           fi

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Resolve environment tier
         id: resolve
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" == "schedule" ]; then
             echo "runner_env=prod" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -26,6 +26,7 @@ env:
 
 jobs:
 
+  # ── JOB 1: PLAN ────────────────────────────────────────────────────────────
   plan:
     name: "Plan – Generate Retention Plan"
     runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -67,7 +68,14 @@ jobs:
         id: meta
         working-directory: ${{ github.workspace }}/scripts/set_log_retention
         run: |
-          PLAN_FILE=$(ls retention-plan-*.json | head -n 1)
+          PLAN_FILE=$(ls retention-plan-*.json 2>/dev/null | head -n 1)
+
+          if [ -z "$PLAN_FILE" ]; then
+            echo "Err No retention plan file found in $(pwd)"
+            ls -la
+            exit 1
+          fi
+
           COMMAND_COUNT=$(jq '.commands | length' "$PLAN_FILE")
 
           echo "plan_file=${PLAN_FILE}" >> "$GITHUB_OUTPUT"
@@ -96,7 +104,6 @@ jobs:
           name: retention-plan
           path: |
             ${{ github.workspace }}/scripts/set_log_retention/retention-plan-*.json
-            ${{ github.workspace }}/scripts/set_log_retention/retention-report-*.csv
           retention-days: 7
 
   # ── JOB 2: APPROVE (manual gate) ───────────────────────────────────────────

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -77,8 +77,12 @@ jobs:
           fi
 
           COMMAND_COUNT=$(jq '.commands | length' "$PLAN_FILE")
+          GENERATED_AT=$(jq -r '.generated_at' "$PLAN_FILE")
 
-          echo "plan_file=${PLAN_FILE}" >> "$GITHUB_OUTPUT"
+          echo "plan_file=${PLAN_FILE}"           >> "$GITHUB_OUTPUT"
+          echo "command_count=${COMMAND_COUNT}"   >> "$GITHUB_OUTPUT"
+          echo "target_env=${{ env.TARGET_ENV }}" >> "$GITHUB_OUTPUT"
+          echo "generated_at=${GENERATED_AT}"     >> "$GITHUB_OUTPUT"
 
           if [ "$COMMAND_COUNT" -gt 0 ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -97,18 +101,10 @@ jobs:
           echo "\`\`\`json"                                        >> "$GITHUB_STEP_SUMMARY"
           jq '.commands' "$PLAN_FILE"                             >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`"                                            >> "$GITHUB_STEP_SUMMARY"
-
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "---" >> "$GITHUB_STEP_SUMMARY"
-          echo " **Download the \`retention-plan\` artifact from the bottom of this page before approving.**" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload plan artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: retention-plan
-          path: |
-            ${{ github.workspace }}/scripts/set_log_retention/retention-plan-*.json
-          retention-days: 7
+          echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
+          echo "---"                                               >> "$GITHUB_STEP_SUMMARY"
+          echo "**Download the \`retention-plan\` artifact from the bottom of this page before approving.**" >> "$GITHUB_STEP_SUMMARY"
+          
 
   # ── JOB 2: APPROVE (manual gate) ───────────────────────────────────────────
   approve:
@@ -119,11 +115,30 @@ jobs:
     environment: compliance-approval
 
     steps:
+      - name: Display plan summary for review
+        run: |
+          echo "## 📋 Retention Plan Pending Approval"           >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
+          echo "| Key | Value |"                                  >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ----- |"                                  >> "$GITHUB_STEP_SUMMARY"
+          echo "| Plan file | \`${{ needs.plan.outputs.plan_file }}\` |"       >> "$GITHUB_STEP_SUMMARY"
+          echo "| Target env | \`${{ needs.plan.outputs.target_env }}\` |"     >> "$GITHUB_STEP_SUMMARY"
+          echo "| Generated at | \`${{ needs.plan.outputs.generated_at }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commands to apply | **${{ needs.plan.outputs.command_count }}** |" >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
+          echo "---"                                               >> "$GITHUB_STEP_SUMMARY"
+          echo " **Download the \`retention-plan\` artifact from the bottom of the run page to review the full command list before approving.**" >> "$GITHUB_STEP_SUMMARY"
+          echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
+          echo " [View full plan job summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Approval confirmed
         run: |
           echo "Plan reviewed and approved."
-          echo "Plan file: ${{ needs.plan.outputs.plan_file }}"
+          echo "Plan file:  ${{ needs.plan.outputs.plan_file }}"
+          echo "Target env: ${{ needs.plan.outputs.target_env }}"
+          echo "Commands:   ${{ needs.plan.outputs.command_count }}"
           echo "Proceeding to apply retention policy changes."
+          
 
   # ── JOB 3: APPLY ───────────────────────────────────────────────────────────
   apply:

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -23,7 +23,6 @@ env:
   AWS_REGION:     us-east-1
   RETENTION_DAYS: ${{ github.event.inputs.retention_days || '180' }}
   TARGET_ENV:     ${{ github.event.inputs.target_env || 'prod' }}
-  PYTHON_VERSION: "3.13.12"
 
 jobs:
 
@@ -39,10 +38,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.0
 
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.2.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Check available Python
+        run: |
+          python3 --version
+          which python3
 
       - name: Install dependencies
         run: pip install -r requirements.txt
@@ -122,11 +121,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.0
-
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.2.0
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -2,7 +2,6 @@ name: CloudWatch Log Retention Manager
 
 on:
   schedule:
-    # Every Monday at 10:00 ET (14:00 UTC)
     - cron: "0 14 * * 1"
   workflow_dispatch:
     inputs:
@@ -21,14 +20,17 @@ permissions:
 
 env:
   AWS_REGION:     us-east-1
-  RETENTION_DAYS: ${{ github.event.inputs.retention_days || '180' }}
-  TARGET_ENV:     ${{ github.event.inputs.target_env || 'prod' }}
+  RETENTION_DAYS: ${{ github.event_name == 'schedule' && '180' || github.event.inputs.retention_days || '180' }}
+  TARGET_ENV:     ${{ github.event_name == 'schedule' && 'prod' || github.event.inputs.target_env || 'prod' }}
 
 jobs:
 
   plan:
     name: "Plan – Generate Retention Plan"
     runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
+    defaults:
+      run:
+        working-directory: scripts/set_cloudwatch_retention
 
     outputs:
       plan_file:   ${{ steps.meta.outputs.plan_file }}
@@ -44,7 +46,7 @@ jobs:
           which python3
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: python3 -m pip install -r requirements.txt
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v4.1.0
@@ -58,7 +60,7 @@ jobs:
           AWS_REGION:     ${{ vars.AWS_REGION }}
           RETENTION_DAYS: ${{ env.RETENTION_DAYS }}
           TARGET_ENV:     ${{ env.TARGET_ENV }}
-        run: python set_log_retention.py
+        run: python3 set_log_retention.py
 
       - name: Collect metadata
         id: meta
@@ -86,17 +88,15 @@ jobs:
           jq '.commands' "$PLAN_FILE"                             >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`"                                            >> "$GITHUB_STEP_SUMMARY"
 
-      # Reviewers can download this directly from the Actions UI before approving
       - name: Upload plan artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: retention-plan
           path: |
-            retention-plan-*.json
-            retention-report-*.csv
+            scripts/set_cloudwatch_retention/retention-plan-*.json
+            scripts/set_cloudwatch_retention/retention-report-*.csv
           retention-days: 7
 
-  # ── JOB 2: APPROVE (manual gate) ───────────────────────────────────────────
   approve:
     name: "Approve – Review Plan Before Applying"
     needs: plan
@@ -111,19 +111,21 @@ jobs:
           echo "Plan file: ${{ needs.plan.outputs.plan_file }}"
           echo "Proceeding to apply retention policy changes."
 
-  # ── JOB 3: APPLY ───────────────────────────────────────────────────────────
   apply:
     name: "Apply – Execute Retention Policy Updates"
     needs: [plan, approve]
     if: needs.plan.outputs.has_changes == 'true'
     runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
+    defaults:
+      run:
+        working-directory: scripts/set_cloudwatch_retention
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.0
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: python3 -m pip install -r requirements.txt
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v4.1.0
@@ -131,11 +133,11 @@ jobs:
           role-to-assume: arn:aws:iam::${{ github.ref_name == 'main' && secrets.PROD_ACCOUNT || secrets.NON_PROD_ACCOUNT }}:role/delegatedadmin/developer/${{ github.ref_name == 'main' && 'cdap-prod' || 'cdap-test' }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
 
-      # Download the exact artifact that was reviewed and approved
       - name: Download plan artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: retention-plan
+          path: scripts/set_cloudwatch_retention
 
       - name: Locate plan file
         id: find-plan
@@ -148,13 +150,12 @@ jobs:
           MODE:       apply
           PLAN_FILE:  ${{ steps.find-plan.outputs.plan_file }}
           AWS_REGION: ${{ vars.AWS_REGION }}
-        run: python set_log_retention.py
+        run: python3 set_log_retention.py
 
-      # Upload the report as a separate artifact for auditing
       - name: Upload apply report artifact
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: retention-apply-report
-          path: retention-report-*.csv
+          path: scripts/set_cloudwatch_retention/retention-report-*.csv
           retention-days: 30

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -2,7 +2,6 @@ name: CloudWatch Log Retention Manager
 
 on:
   schedule:
-    # Every Monday at 10:00 ET (14:00 UTC)
     - cron: "0 14 * * 1"
   workflow_dispatch:
     inputs:
@@ -11,7 +10,7 @@ on:
         required: false
         default: "180"
       target_env:
-        description: "Target environment string (e.g. prod, test, dev, sandbox)"
+        description: "Target environment string (e.g. ephemeral-prod, happy-test, nice-sandbox, dev)"
         required: true
         default: "prod"
 
@@ -20,25 +19,50 @@ permissions:
   id-token: write
 
 env:
-  AWS_REGION: us-east-1
+  AWS_REGION:     us-east-1
   RETENTION_DAYS: ${{ github.event_name == 'schedule' && '180' || github.event.inputs.retention_days || '180' }}
-  TARGET_ENV: ${{ github.event_name == 'schedule' && 'prod' || github.event.inputs.target_env || 'prod' }}
+  TARGET_ENV:     ${{ github.event_name == 'schedule' && 'prod' || github.event.inputs.target_env || 'prod' }}
 
 jobs:
 
   # -- JOB 1: PLAN ------------------------------------------------------------
   plan:
     name: "Plan - Generate Retention Plan"
-    runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: >-
+      codebuild-cdap-${{
+        (github.event_name == 'schedule'
+          || contains(github.event.inputs.target_env, 'prod')
+          || contains(github.event.inputs.target_env, 'sandbox'))
+        && 'prod'
+        || 'non-prod'
+      }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     outputs:
-      plan_file: ${{ steps.meta.outputs.plan_file }}
-      has_changes: ${{ steps.meta.outputs.has_changes }}
+      plan_file:     ${{ steps.meta.outputs.plan_file }}
+      has_changes:   ${{ steps.meta.outputs.has_changes }}
       command_count: ${{ steps.meta.outputs.command_count }}
-      target_env: ${{ steps.meta.outputs.target_env }}
-      generated_at: ${{ steps.meta.outputs.generated_at }}
+      target_env:    ${{ steps.meta.outputs.target_env }}
+      generated_at:  ${{ steps.meta.outputs.generated_at }}
+      runner_env:    ${{ steps.resolve.outputs.runner_env }}
 
     steps:
+      - name: Resolve environment tier
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            echo "runner_env=prod" >> "$GITHUB_OUTPUT"
+          else
+            INPUT_ENV="${{ github.event.inputs.target_env }}"
+            if echo "$INPUT_ENV" | grep -qiE 'prod|sandbox'; then
+              echo "runner_env=prod"     >> "$GITHUB_OUTPUT"
+            elif echo "$INPUT_ENV" | grep -qiE 'dev|test'; then
+              echo "runner_env=non_prod" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Environment '${INPUT_ENV}' must contain one of: prod, sandbox, dev, test"
+              exit 1
+            fi
+          fi
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.3.0
 
@@ -55,16 +79,25 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ github.ref_name == 'main' && secrets.PROD_ACCOUNT || secrets.NON_PROD_ACCOUNT }}:role/delegatedadmin/developer/${{ github.ref_name == 'main' && 'cdap-prod' || 'cdap-test' }}-github-actions
+          role-to-assume: >-
+            arn:aws:iam::${{
+              steps.resolve.outputs.runner_env == 'prod'
+              && secrets.PROD_ACCOUNT
+              || secrets.NON_PROD_ACCOUNT
+            }}:role/delegatedadmin/developer/${{
+              steps.resolve.outputs.runner_env == 'prod'
+              && 'cdap-prod'
+              || 'cdap-test'
+            }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Run plan
         working-directory: ${{ github.workspace }}/scripts/set_log_retention
         env:
-          MODE: plan
-          AWS_REGION: ${{ vars.AWS_REGION }}
+          MODE:           plan
+          AWS_REGION:     ${{ vars.AWS_REGION }}
           RETENTION_DAYS: ${{ env.RETENTION_DAYS }}
-          TARGET_ENV: ${{ env.TARGET_ENV }}
+          TARGET_ENV:     ${{ env.TARGET_ENV }}
         run: python3 set_log_retention.py
 
       - name: Collect metadata
@@ -72,27 +105,27 @@ jobs:
         working-directory: ${{ github.workspace }}/scripts/set_log_retention
         run: |
           PLAN_FILE=$(ls retention-plan-*.json 2>/dev/null | head -n 1)
-          
+
           if [ -z "$PLAN_FILE" ]; then
             echo "No retention plan file found in $(pwd)"
             ls -la
             exit 1
           fi
-          
+
           COMMAND_COUNT=$(jq '.commands | length' "$PLAN_FILE")
           GENERATED_AT=$(jq -r '.generated_at' "$PLAN_FILE")
-          
+
           echo "plan_file=${PLAN_FILE}"           >> "$GITHUB_OUTPUT"
           echo "command_count=${COMMAND_COUNT}"   >> "$GITHUB_OUTPUT"
           echo "target_env=${{ env.TARGET_ENV }}" >> "$GITHUB_OUTPUT"
           echo "generated_at=${GENERATED_AT}"     >> "$GITHUB_OUTPUT"
-          
+
           if [ "$COMMAND_COUNT" -gt 0 ]; then
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "has_changes=true"  >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           fi
-          
+
           echo "### Retention Plan"                               >> "$GITHUB_STEP_SUMMARY"
           echo "| Key | Value |"                                  >> "$GITHUB_STEP_SUMMARY"
           echo "| --- | ----- |"                                  >> "$GITHUB_STEP_SUMMARY"
@@ -103,9 +136,9 @@ jobs:
           echo "#### Commands"                                     >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`json"                                        >> "$GITHUB_STEP_SUMMARY"
           jq '.commands' "$PLAN_FILE"                             >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`"                                            >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`"                                           >> "$GITHUB_STEP_SUMMARY"
           echo ""                                                  >> "$GITHUB_STEP_SUMMARY"
-          echo "---"                                               >> "$GITHUB_STEP_SUMMARY"
+          echo "---"                                              >> "$GITHUB_STEP_SUMMARY"
           echo "Download the \`retention-plan\` artifact from the bottom of this page before approving." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload plan artifact
@@ -121,32 +154,27 @@ jobs:
     needs: plan
     if: needs.plan.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-
     steps:
       - name: Post plan summary for reviewer
         run: |
-          echo "## Retention Plan Awaiting Approval"                                       >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                                           >> "$GITHUB_STEP_SUMMARY"
-          echo "| Key | Value |"                                                           >> "$GITHUB_STEP_SUMMARY"
-          echo "| --- | ----- |"                                                           >> "$GITHUB_STEP_SUMMARY"
-          echo "| Plan file    | \`${{ needs.plan.outputs.plan_file }}\` |"                >> "$GITHUB_STEP_SUMMARY"
-          echo "| Target env   | \`${{ needs.plan.outputs.target_env }}\` |"               >> "$GITHUB_STEP_SUMMARY"
-          echo "| Generated at | \`${{ needs.plan.outputs.generated_at }}\` |"            >> "$GITHUB_STEP_SUMMARY"
-          echo "| Commands     | **${{ needs.plan.outputs.command_count }}** |"           >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                                           >> "$GITHUB_STEP_SUMMARY"
-          echo "---"                                                                        >> "$GITHUB_STEP_SUMMARY"
+          echo "## Retention Plan Awaiting Approval"                                        >> "$GITHUB_STEP_SUMMARY"
+          echo "| Key | Value |"                                                            >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ----- |"                                                            >> "$GITHUB_STEP_SUMMARY"
+          echo "| Plan file    | \`${{ needs.plan.outputs.plan_file }}\` |"                 >> "$GITHUB_STEP_SUMMARY"
+          echo "| Target env   | \`${{ needs.plan.outputs.target_env }}\` |"                >> "$GITHUB_STEP_SUMMARY"
+          echo "| Generated at | \`${{ needs.plan.outputs.generated_at }}\` |"             >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commands     | **${{ needs.plan.outputs.command_count }}** |"            >> "$GITHUB_STEP_SUMMARY"
+          echo "---"                                                                         >> "$GITHUB_STEP_SUMMARY"
           echo "Scroll down and download the \`retention-plan\` artifact before approving." >> "$GITHUB_STEP_SUMMARY"
-          echo ""                                                                           >> "$GITHUB_STEP_SUMMARY"
-          echo "Once reviewed, click **Review deployments** to approve or reject."         >> "$GITHUB_STEP_SUMMARY"
+          echo "Once reviewed, click **Review deployments** to approve or reject."          >> "$GITHUB_STEP_SUMMARY"
 
-  # -- JOB 3: APPROVE (manual gate) -------------------------------------------
+  # -- JOB 3: APPROVE ---------------------------------------------------------
   approve:
     name: "Approve - Review Plan Before Applying"
-    needs: [ plan, notify ]
+    needs: [plan, notify]
     if: needs.plan.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     environment: compliance-approval
-
     steps:
       - name: Approval confirmed
         run: |
@@ -158,9 +186,14 @@ jobs:
   # -- JOB 4: APPLY -----------------------------------------------------------
   apply:
     name: "Apply - Execute Retention Policy Updates"
-    needs: [ plan, approve ]
+    needs: [plan, approve]
     if: needs.plan.outputs.has_changes == 'true'
-    runs-on: codebuild-cdap-${{ github.ref_name == 'main' && 'prod' || 'non-prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: >-
+      codebuild-cdap-${{
+        needs.plan.outputs.runner_env == 'prod'
+        && 'prod'
+        || 'non-prod'
+      }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Checkout
@@ -173,7 +206,16 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v4.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ github.ref_name == 'main' && secrets.PROD_ACCOUNT || secrets.NON_PROD_ACCOUNT }}:role/delegatedadmin/developer/${{ github.ref_name == 'main' && 'cdap-prod' || 'cdap-test' }}-github-actions
+          role-to-assume: >-
+            arn:aws:iam::${{
+              needs.plan.outputs.runner_env == 'prod'
+              && secrets.PROD_ACCOUNT
+              || secrets.NON_PROD_ACCOUNT
+            }}:role/delegatedadmin/developer/${{
+              needs.plan.outputs.runner_env == 'prod'
+              && 'cdap-prod'
+              || 'cdap-test'
+            }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Download plan artifact
@@ -192,8 +234,8 @@ jobs:
       - name: Apply retention plan
         working-directory: ${{ github.workspace }}/scripts/set_log_retention
         env:
-          MODE: apply
-          PLAN_FILE: ${{ steps.find-plan.outputs.plan_file }}
+          MODE:       apply
+          PLAN_FILE:  ${{ steps.find-plan.outputs.plan_file }}
           AWS_REGION: ${{ vars.AWS_REGION }}
         run: python3 set_log_retention.py
 
@@ -204,4 +246,3 @@ jobs:
           name: retention-apply-report
           path: ${{ github.workspace }}/scripts/set_log_retention/retention-report-*.csv
           retention-days: 30
-

--- a/.github/workflows/set-log-retention.yml
+++ b/.github/workflows/set-log-retention.yml
@@ -98,6 +98,10 @@ jobs:
           jq '.commands' "$PLAN_FILE"                             >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`"                                            >> "$GITHUB_STEP_SUMMARY"
 
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "---" >> "$GITHUB_STEP_SUMMARY"
+          echo " **Download the \`retention-plan\` artifact from the bottom of this page before approving.**" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload plan artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/scripts/set_log_retention/set_log_retention.py
+++ b/scripts/set_log_retention/set_log_retention.py
@@ -35,24 +35,7 @@ PLAN_FILE   = f"retention-plan-{DATE_TAG}.json"
 REPORT_FILE = f"retention-report-{DATE_TAG}.csv"
 
 # Log groups excluded because their retention is managed by Terraform.
-EXCLUSION_LIST = {
-    "/aws/kinesisfirehose/bfd-insights-bcda-prod-get_job_data",
-    "/aws/kinesisfirehose/bfd-insights-bcda-prod-bfd-insights-get_stale_pending_jobs",
-    "/aws/kinesisfirehose/bfd-insights-bcda-prod-get_active_acos",
-    "/aws/kinesisfirehose/bfd-insights-bcda-prod-get_stale_cclf_imports",
-    "/aws/kinesisfirehose/bfd-insights-bcda-prod-get_num_benes_per_aco",
-    "/aws/kinesisfirehose/bfd-insights-bcda-prod-get_suppression_metrics",
-    "/aws/kinesisfirehose/bfd-insights-bcda-prod-get_num_days_to_make_first_request",
-    "/aws/kinesisfirehose/bfd-insights-bcda-prod-get_acos_with_expired_credentials",
-    "aws/kinesisfirehose/bfd-insights-bcda-prod-get_job_data",  # intentional: no leading slash
-    "/aws/lambda/insights_data_sampler_prod",
-    "/aws/lambda/ab2d-prod-audit",
-    "/aws/lambda/ab2d-sandbox-audit",
-    "/aws/lambda/ab2d-test-audit",
-    "/aws/lambda/ab2d-dev-audit",
-    "/aws/events/ecs/dpc-prod-backend",
-    "/aws/events/ecs/dpc-prod-frontend",
-}
+EXCLUSION_LIST = {}
 # ---------------------------------------------------------------------------
 
 # Helpers

--- a/scripts/set_log_retention/set_log_retention.py
+++ b/scripts/set_log_retention/set_log_retention.py
@@ -144,16 +144,12 @@ def generate_plan(log_groups: list[dict]) -> tuple[dict, list[dict]]:
 
         if category == "tf_maintained":
             results["tf_maintained"].append({"name": name, "retention": retention})
-
         elif category == "ignored_env":
             results["ignored_env"].append({"name": name, "retention": retention})
-
         elif category == "ignored_cms":
             results["ignored_cms"].append({"name": name})
-
         elif category == "skipped":
             results["skipped"].append({"name": name, "retention": effective_retention})
-
         elif category == "update":
             commands.append({
                 "log_group":         lower_name,
@@ -166,6 +162,7 @@ def generate_plan(log_groups: list[dict]) -> tuple[dict, list[dict]]:
             })
 
     return results, commands
+
 
 def write_plan_file(commands: list[dict]) -> str:
     """Serialise the command list to a timestamped JSON file. Returns the filename."""
@@ -180,3 +177,132 @@ def write_plan_file(commands: list[dict]) -> str:
         json.dump(payload, fh, indent=2)
     print(f"\nPlan written  → {PLAN_FILE}")
     return PLAN_FILE
+
+
+def write_plan_summary(results: dict, commands: list[dict]) -> None:
+    """Print a human-readable summary to stdout."""
+    print("\n" + "=" * 60)
+    print(f"  PLAN SUMMARY")
+    print("=" * 60)
+    print(f"  Total processed : {results['processed']}")
+    print(f"  To update       : {len(commands)}")
+    print(f"  Already OK      : {len(results['skipped'])}")
+    print(f"  TF-managed      : {len(results['tf_maintained'])}")
+    print(f"  CMS-managed     : {len(results['ignored_cms'])}")
+    print(f"  Other env       : {len(results['ignored_env'])}")
+    print("=" * 60)
+
+
+# Apply
+
+def apply_plan(client, plan_path: str) -> None:
+    """
+    Read an approved plan JSON file and apply retention policies via boto3.
+    Exits with code 1 if any updates fail.
+    """
+    if not os.path.exists(plan_path):
+        print(f"Err Plan file not found: {plan_path}")
+        sys.exit(1)
+
+    with open(plan_path) as fh:
+        plan = json.load(fh)
+
+    commands  = plan.get("commands", [])
+    retention = plan.get("retention_days", RETENTION_DAYS)
+    region    = plan.get("region", AWS_REGION)
+
+    print(f"[APPLY] Applying {len(commands)} retention policy update(s)...")
+    print(f"        Region         : {region}")
+    print(f"        Retention days : {retention}")
+    print(f"        Plan file      : {plan_path}")
+    print()
+
+    updated = []
+    failed  = []
+    report_rows = []
+
+    for entry in commands:
+        log_group = entry["log_group"]
+        try:
+            client.put_retention_policy(
+                logGroupName=log_group,
+                retentionInDays=retention,
+            )
+            print(f"   Updated : {log_group}")
+            updated.append(log_group)
+            report_rows.append({
+                "log_group":  log_group,
+                "status":     "updated",
+                "retention":  retention,
+                "error":      "",
+            })
+        except Exception as e:
+            print(f"Err Failed  : {log_group} — {e}")
+            failed.append(log_group)
+            report_rows.append({
+                "log_group":  log_group,
+                "status":     "failed",
+                "retention":  retention,
+                "error":      str(e),
+            })
+
+    # Write CSV report
+    write_report(report_rows)
+
+    print()
+    print("=" * 60)
+    print(f"  APPLY SUMMARY")
+    print("=" * 60)
+    print(f"  Updated : {len(updated)}")
+    print(f"  Failed  : {len(failed)}")
+    print("=" * 60)
+
+    if failed:
+        print(f"\nErr {len(failed)} update(s) failed. See report for details.")
+        sys.exit(1)
+
+    print("\n✅ All retention policies applied successfully.")
+
+
+# Report
+
+def write_report(rows: list[dict]) -> None:
+    """Write a CSV apply report to REPORT_FILE."""
+    if not rows:
+        return
+    with open(REPORT_FILE, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["log_group", "status", "retention", "error"])
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"Report written → {REPORT_FILE}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    mode   = os.environ.get("MODE", "plan").lower()
+    client = boto3.client("logs", region_name=AWS_REGION)
+
+    if mode == "plan":
+        print(f"[PLAN] Scanning log groups for env='{TARGET_ENV}' in {AWS_REGION}...")
+        log_groups = get_all_log_groups(client)
+        results, commands = generate_plan(log_groups)
+        write_plan_summary(results, commands)
+        write_plan_file(commands)
+
+    elif mode == "apply":
+        plan_path = os.environ.get("PLAN_FILE")
+        if not plan_path:
+            print("Err: PLAN_FILE env var is required in apply mode.")
+            sys.exit(1)
+        apply_plan(client, plan_path)
+
+    else:
+        print(f"Err: Unknown MODE: '{mode}'. Expected 'plan' or 'apply'.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🎫 Ticket

PLT-1662

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Leverages the codebuild runner's default python version to run the cloudwatch retention script. 
Allows the log retention script to be run from a branch against any chosen environment. This enables testing and validation. 

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
These changes were made to ensure operability of the cloudwatch retention script via github workflows which was not yet operable. 

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
This was validated by running until the validation checks. Before merging, we will run the apply on production cloudwatch log groups with approval of the team overseeing compliance.   

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
