### PR TITLE
Ls/dpc 5387 quicksight lambda updates

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -21,7 +21,7 @@ resource "aws_s3_bucket_versioning" "this" {
 
 data "aws_kms_alias" "default_encryption_key" {
   count = var.kms_key_arn == null ? 1 : 0
-  name = "alias/${var.app}-${var.env}"
+  name  = "alias/${var.app}-${var.env}"
 }
 
 data "aws_iam_policy_document" "ssl_only" {

--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -19,7 +19,7 @@ resource "aws_s3_bucket_versioning" "this" {
   }
 }
 
-data "aws_kms_alias" "kms_key" {
+data "aws_kms_alias" "default_encryption_key" {
   count = var.kms_key_arn == null ? 1 : 0
   name = "alias/${var.app}-${var.env}"
 }
@@ -72,7 +72,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
       sse_algorithm     = "aws:kms"
       kms_master_key_id = (
         var.kms_key_arn == null ?
-        data.aws_kms_alias.kms_key[0].target_key_arn :
+        data.aws_kms_alias.default_encryption_key[0].target_key_arn :
         var.kms_key_arn
       )
     }

--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -69,7 +69,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
     bucket_key_enabled = true
 
     apply_server_side_encryption_by_default {
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "aws:kms"
       kms_master_key_id = (
         var.kms_key_arn == null ?
         data.aws_kms_alias.default_encryption_key[0].target_key_arn :

--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -20,6 +20,7 @@ resource "aws_s3_bucket_versioning" "this" {
 }
 
 data "aws_kms_alias" "kms_key" {
+  count = var.kms_key_arn == null ? 1 : 0
   name = "alias/${var.app}-${var.env}"
 }
 
@@ -68,11 +69,11 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
     bucket_key_enabled = true
 
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      sse_algorithm     = "aws:kms"
       kms_master_key_id = (
-        var.default_encryption_key_arn == null ?
-        data.aws_kms_alias.kms_key.target_key_arn :
-        var.default_encryption_key_arn
+        var.kms_key_arn == null ?
+        data.aws_kms_alias.kms_key[0].target_key_arn :
+        var.kms_key_arn
       )
     }
   }

--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -68,8 +68,12 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
     bucket_key_enabled = true
 
     apply_server_side_encryption_by_default {
-      kms_master_key_id = data.aws_kms_alias.kms_key.target_key_arn
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "aws:kms"
+      kms_master_key_id = (
+        var.default_encryption_key_arn == null ?
+        data.aws_kms_alias.kms_key.target_key_arn :
+        var.default_encryption_key_arn
+      )
     }
   }
 }

--- a/terraform/modules/bucket/variables.tf
+++ b/terraform/modules/bucket/variables.tf
@@ -13,7 +13,7 @@ variable "app" {
   }
 }
 
-variable "default_encryption_key_arn" {
+variable "kms_key_arn" {
   default     = null
   description = "The ARN of the default S3 bucket encryption key"
   type        = string

--- a/terraform/modules/bucket/variables.tf
+++ b/terraform/modules/bucket/variables.tf
@@ -13,6 +13,12 @@ variable "app" {
   }
 }
 
+variable "default_encryption_key_arn" {
+  default     = null
+  description = "The ARN of the default S3 bucket encryption key"
+  type        = string
+}
+
 variable "env" {
   description = "The application environment (dev, test, sandbox, prod, mgmt)"
   type        = string


### PR DESCRIPTION
## 🎫 Ticket
DPC-5387

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - define new _optional_ input variable for bucket module's encryption key
   - default behavior remains exactly the same

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - For DPC's we have a use case where we want to explicitly specify a key for s3 to use for encrypting files.
  - For quicksight reporting, the same bucket is used by
    -  1. postgres extension(s) to output data - Example query `create_job()` query [HERE](https://github.com/CMSgov/dpc-app/blob/main/scripts/schedule_view_exports.sql#L43)
    - 2. python lambda to process data into a report
  - Previous dpc-ops changes relied on a free-floating feature branch from this repository specified [HERE](https://github.com/CMSgov/dpc-ops/blob/f19985817a3165bd2e227914b2c557ef7575849d/terraform/lambda/quicksight-reports/main.tf#L79) 
    - This PR is intended to be merged before further dpc-ops changes to avoid code becoming brittle based on a separate branch

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Tested in dpc `test` environment. See Validation section in dpc-ops PR: https://github.com/CMSgov/dpc-ops/pull/947