### PR TITLE
AB2D-7227 update to java25

### DIFF
--- a/terraform/modules/platform/main.tf
+++ b/terraform/modules/platform/main.tf
@@ -115,7 +115,7 @@ data "aws_s3_bucket" "access_logs" {
 }
 
 data "aws_s3_bucket" "logs_to_splunk" {
-  bucket = "cms-cloud-${data.aws_caller_identity.this.account_id}-${data.aws_region.primary.name}"
+  bucket = "cms-cloud-${data.aws_caller_identity.this.account_id}-${data.aws_region.primary.region}"
 }
 
 data "aws_security_groups" "this" {

--- a/terraform/modules/platform/terraform.tf
+++ b/terraform/modules/platform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~>5"
+      version               = "~>6"
       configuration_aliases = [aws.secondary]
     }
   }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7227

## 🛠 Changes

Bumps the version of the aws provider to v6, and alters one field deprecated in the new version.

## ℹ️ Context

AB2D is upgrading Java to version 25, and the aws provider v5 only supports up to version 21. This change keeps the version of the aws provider aligned and prevents mismatch errors on AB2Ds side. This change will support upgrades to java in this PR: https://github.com/CMSgov/ab2d/pull/1769


## 🧪 Validation

Updated platform ref used in the AB2D lambdas, works as expected and can find Java25.