### PR TITLE
BCDA-9967: add model short name

### DIFF
--- a/terraform/services/insights/views/bcda/prod-jobs-with-cms-id.view.sql
+++ b/terraform/services/insights/views/bcda/prod-jobs-with-cms-id.view.sql
@@ -11,6 +11,20 @@ SELECT
     jobs.transaction_time,
     jobs.benes_attributed_to_aco,
     acos.cms_id,
+    CASE
+        WHEN acos.cms_id ~ 'D\d{4}' THEN 'ACO REACH'
+        WHEN acos.cms_id ~ 'K\d{4}' THEN 'KCC'
+        WHEN acos.cms_id ~ 'C\d{4}' THEN 'KCC'
+        WHEN acos.cms_id ~ 'CT\d{6}' THEN 'MD TCoC'
+        WHEN acos.cms_id ~ '^A\d{4}' THEN 'SSP'
+        WHEN acos.cms_id ~ 'IOTA\d{3}' THEN 'IOTA'
+        WHEN acos.cms_id ~ 'GUIDE-\d{5}' THEN 'GUIDE'
+        WHEN acos.cms_id ~ 'DA\d{4}' THEN 'CDAC'
+        WHEN acos.cms_id ~ 'TEST\d{3}' THEN 'TEST'
+        WHEN acos.cms_id ~ 'V\d{3}' THEN 'NGACO'
+        WHEN acos.cms_id ~ 'E\d{4}' THEN 'CEC'
+        ELSE 'Unknown'
+    END AS model_name,
     sq.benes_with_data,
     sq.benes_retrieved_percent
 FROM jobs

--- a/terraform/services/insights/views/bcda/sandbox-jobs-with-cms-id.view.sql
+++ b/terraform/services/insights/views/bcda/sandbox-jobs-with-cms-id.view.sql
@@ -12,6 +12,23 @@ SELECT
     jobs.transaction_time,
     jobs.benes_attributed_to_aco,
     acos.cms_id,
+    CASE
+        WHEN acos.cms_id ~ 'D\d{4}' THEN 'ACO REACH'
+        WHEN acos.cms_id ~ 'K\d{4}' THEN 'KCC'
+        WHEN acos.cms_id ~ 'C\d{4}' THEN 'KCC'
+        WHEN acos.cms_id ~ 'CT\d{6}' THEN 'MD TCoC'
+        WHEN acos.cms_id ~ '^A\d{4}' THEN 'SSP'
+        WHEN acos.cms_id ~ 'IOTA\d{3}' THEN 'IOTA'
+        WHEN acos.cms_id ~ 'GUIDE-\d{5}' THEN 'GUIDE'
+        WHEN acos.cms_id ~ 'DA\d{4}' THEN 'CDAC'
+        WHEN acos.cms_id ~ 'TEST\d{3}' THEN 'TEST'
+        WHEN acos.cms_id ~ 'V\d{3}' THEN 'NGACO'
+        WHEN acos.cms_id ~ 'E\d{4}' THEN 'CEC'
+        WHEN acos.cms_id ~ 'SBXA\w\d{3}' THEN 'Sandbox Adj'
+        WHEN acos.cms_id ~ 'SBXP\w\d{3}' THEN 'Sandbox Partially-Adj'
+        WHEN acos.cms_id ~ 'SBXB\w\d{3}' THEN 'Sandbox Both'
+        ELSE 'Unknown'
+    END AS model_name,
     sq.benes_with_data,
     sq.benes_retrieved_percent
 FROM jobs


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9967

## 🛠 Changes

Adding `model_name` to the production and sandbox jobs view

## ℹ️ Context

We want to have the Alternative Payment Model included in job request data so that it can be easily aggregated, without having to derive the model from each entity's CMS ID

## 🧪 Validation

Executed queries against prod/sandbox locally
