### PR TITLE
BCDA-9967: update column order to match existing view

### DIFF
--- a/terraform/services/insights/views/bcda/prod-jobs-with-cms-id.view.sql
+++ b/terraform/services/insights/views/bcda/prod-jobs-with-cms-id.view.sql
@@ -9,8 +9,10 @@ SELECT
     jobs.updated_at,
     jobs.job_count,
     jobs.transaction_time,
-    jobs.benes_attributed_to_aco,
     acos.cms_id,
+    jobs.benes_attributed_to_aco,
+    sq.benes_with_data,
+    sq.benes_retrieved_percent,
     CASE
         WHEN acos.cms_id ~ 'D\d{4}' THEN 'ACO REACH'
         WHEN acos.cms_id ~ 'K\d{4}' THEN 'KCC'
@@ -24,9 +26,7 @@ SELECT
         WHEN acos.cms_id ~ 'V\d{3}' THEN 'NGACO'
         WHEN acos.cms_id ~ 'E\d{4}' THEN 'CEC'
         ELSE 'Unknown'
-    END AS model_name,
-    sq.benes_with_data,
-    sq.benes_retrieved_percent
+    END AS model_name
 FROM jobs
 LEFT JOIN acos ON acos.uuid = jobs.aco_id
 JOIN (

--- a/terraform/services/insights/views/bcda/prod-jobs-with-cms-id.view.sql
+++ b/terraform/services/insights/views/bcda/prod-jobs-with-cms-id.view.sql
@@ -11,6 +11,20 @@ SELECT
     jobs.transaction_time,
     jobs.benes_attributed_to_aco,
     acos.cms_id,
+    CASE
+        WHEN acos.cms_id ~ 'D\d{4}' THEN 'ACO REACH'
+        WHEN acos.cms_id ~ 'K\d{4}' THEN 'KCC'
+        WHEN acos.cms_id ~ 'C\d{4}' THEN 'KCC'
+        WHEN acos.cms_id ~ 'CT\d{6}' THEN 'MD TCoC'
+        WHEN acos.cms_id ~ '^A\d{4}' THEN 'SSP'
+        WHEN acos.cms_id ~ 'IOTA\d{3}' THEN 'IOTA'
+        WHEN acos.cms_id ~ 'GUIDE-\d{5}' THEN 'GUIDE'
+        WHEN acos.cms_id ~ 'DA\d{4}' THEN 'CDAC'
+        WHEN acos.cms_id ~ 'TEST\d{3}' THEN 'TEST'
+        WHEN acos.cms_id ~ 'V\d{3}' THEN 'NGACO'
+        WHEN acos.cms_id ~ 'E\d{4}' THEN 'CEC'
+        ELSE 'Unknown'
+    END AS model_name,
     sq.benes_with_data,
     sq.benes_retrieved_percent
 FROM jobs

--- a/terraform/services/insights/views/bcda/sandbox-jobs-with-cms-id.view.sql
+++ b/terraform/services/insights/views/bcda/sandbox-jobs-with-cms-id.view.sql
@@ -12,6 +12,23 @@ SELECT
     jobs.transaction_time,
     jobs.benes_attributed_to_aco,
     acos.cms_id,
+    CASE
+        WHEN acos.cms_id ~ 'D\d{4}' THEN 'ACO REACH'
+        WHEN acos.cms_id ~ 'K\d{4}' THEN 'KCC'
+        WHEN acos.cms_id ~ 'C\d{4}' THEN 'KCC'
+        WHEN acos.cms_id ~ 'CT\d{6}' THEN 'MD TCoC'
+        WHEN acos.cms_id ~ '^A\d{4}' THEN 'SSP'
+        WHEN acos.cms_id ~ 'IOTA\d{3}' THEN 'IOTA'
+        WHEN acos.cms_id ~ 'GUIDE-\d{5}' THEN 'GUIDE'
+        WHEN acos.cms_id ~ 'DA\d{4}' THEN 'CDAC'
+        WHEN acos.cms_id ~ 'TEST\d{3}' THEN 'TEST'
+        WHEN acos.cms_id ~ 'V\d{3}' THEN 'NGACO'
+        WHEN acos.cms_id ~ 'E\d{4}' THEN 'CEC'
+        WHEN acos.cms_id ~ 'SBXA\w\d{3}' THEN 'Sandbox Adj'
+        WHEN acos.cms_id ~ 'SBXP\w\d{3}' THEN 'Sandbox Partially-Adj'
+        WHEN acos.cms_id ~ 'SBXB\w\d{3}' THEN 'Sandbox Both'
+        ELSE 'Unknown'
+    END AS model_name,
     sq.benes_with_data,
     sq.benes_retrieved_percent
 FROM jobs

--- a/terraform/services/insights/views/bcda/sandbox-jobs-with-cms-id.view.sql
+++ b/terraform/services/insights/views/bcda/sandbox-jobs-with-cms-id.view.sql
@@ -10,8 +10,10 @@ SELECT
     jobs.updated_at,
     jobs.job_count,
     jobs.transaction_time,
-    jobs.benes_attributed_to_aco,
     acos.cms_id,
+    jobs.benes_attributed_to_aco,
+    sq.benes_with_data,
+    sq.benes_retrieved_percent,
     CASE
         WHEN acos.cms_id ~ 'D\d{4}' THEN 'ACO REACH'
         WHEN acos.cms_id ~ 'K\d{4}' THEN 'KCC'
@@ -28,14 +30,11 @@ SELECT
         WHEN acos.cms_id ~ 'SBXP\w\d{3}' THEN 'Sandbox Partially-Adj'
         WHEN acos.cms_id ~ 'SBXB\w\d{3}' THEN 'Sandbox Both'
         ELSE 'Unknown'
-    END AS model_name,
-    sq.benes_with_data,
-    sq.benes_retrieved_percent
+    END AS model_name
 FROM jobs
 LEFT JOIN acos ON acos.uuid = jobs.aco_id
 JOIN (
 	SELECT job_id, SUM(benes_with_data) AS benes_with_data, AVG(benes_retrieved_percent) AS benes_retrieved_percent FROM job_keys
 	GROUP BY job_id
 ) AS sq
-ON sq.job_id = jobs.id 
-
+ON sq.job_id = jobs.id


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9967

## 🛠 Changes

Updated column order to match the existing view

## ℹ️ Context

Postgres rigidly maintains the existing column order for the existing view unless we drop and recreate the view. The earlier PR merged (#461) yields error:

```
SQL Error [42P16]: ERROR: cannot change name of view column "cms_id" to "benes_attributed_to_aco"
  Hint: Use ALTER VIEW ... RENAME COLUMN ... to change name of view column instead.
```

## 🧪 Validation

Executed/Updated views (without errors) and checked retrieved data
