### PR TITLE
AB2D-7269 Pin Aurora Version to default latest

### DIFF
--- a/terraform/modules/aurora/README.md
+++ b/terraform/modules/aurora/README.md
@@ -152,7 +152,7 @@ No requirements.
 | <a name="input_cluster_instance_parameters"></a> [cluster\_instance\_parameters](#input\_cluster\_instance\_parameters) | A list of objects containing the values for apply\_method, name, and value that corresponds to the instance-level prameters. | <pre>list(object({<br/>    apply_method = string<br/>    name         = string<br/>    value        = any<br/>  }))</pre> | `[]` | no |
 | <a name="input_cluster_parameters"></a> [cluster\_parameters](#input\_cluster\_parameters) | A list of objects containing the values for apply\_method, name, and value that corresponds to the cluster-level prameters. | <pre>list(object({<br/>    apply_method = string<br/>    name         = string<br/>    value        = any<br/>  }))</pre> | `[]` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the DB cluster should have deletion protection enabled. | `bool` | `true` | no |
-| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Selected engine version for either RDS DB Instance or RDS Aurora DB Cluster. | `string` | `"16.8"` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Selected major engine version for either RDS DB Instance or RDS Aurora DB Cluster. | `string` | `"16"` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Desired number of cluster instances | `number` | `1` | no |
 | <a name="input_kms_key_override"></a> [kms\_key\_override](#input\_kms\_key\_override) | Override to the platform-managed KMS key | `string` | `null` | no |
 | <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The [monitoring\_interval](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#monitoring_interval-1) in seconds determines the time between sampling enhanced monitoring metrics for the cluster. | `number` | `15` | no |
@@ -188,6 +188,7 @@ No modules.
 | [aws_rds_cluster_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_parameter_group) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_security_group_egress_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_rds_engine_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/rds_engine_version) | data source |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'

--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -65,10 +65,17 @@ resource "aws_db_parameter_group" "this" {
   }
 }
 
+data "aws_rds_engine_version" "this" {
+  engine       = "aurora-postgresql"
+  version      = var.engine_version
+  default_only = true
+  latest       = true
+}
+
 resource "aws_rds_cluster" "this" {
   cluster_identifier                  = coalesce(var.cluster_identifier, local.service_prefix)
   engine                              = local.aurora_engine
-  engine_version                      = var.engine_version
+  engine_version                      = data.aws_rds_engine_version.this.version
   master_username                     = var.username
   master_password                     = var.password
   snapshot_identifier                 = var.snapshot_identifier

--- a/terraform/modules/aurora/variables.tf
+++ b/terraform/modules/aurora/variables.tf
@@ -97,8 +97,8 @@ variable "cluster_instance_parameters" {
 }
 
 variable "engine_version" {
-  default     = "16.8"
-  description = "Selected engine version for either RDS DB Instance or RDS Aurora DB Cluster."
+  default     = "16"
+  description = "Selected major engine version for either RDS DB Instance or RDS Aurora DB Cluster."
   type        = string
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-7269

## 🛠 Changes

Adds a data lookup for AWS's default latest aurora version

## ℹ️ Context

This should fix the automatic version updates to AWS Aurora engine_version from breaking tofu applies, since we will dynamically get the version AWS insists on updating to in the code.

## 🧪 Validation

Confirmed that the version matches with the version that was updated to automatically (AB2D DEV):
```
module.db.aws_rds_cluster_instance.this[0]: Refreshing state... [id=ab2d-dev-0]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no
changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```
