### PR TITLE
PLT-1666: Alarm to paths permissions fixes

### DIFF
--- a/.github/workflows/alarm-to-slack-checks.yml
+++ b/.github/workflows/alarm-to-slack-checks.yml
@@ -1,0 +1,21 @@
+name: code-checks (set-log-retention-checks / cloudwatch log retention)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'terraform/services/alarm-to-slack/lambda_src/*.py'
+      - 'terraform/services/alarm-to-slack/lambda_src/requirements.txt'
+      - '.github/workflows/alarm-to-slack-checks.yml'
+      - '.github/workflows/checks-reusable.yml'
+
+jobs:
+  checks:
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/checks-reusable.yml
+    secrets: inherit
+    with:
+      source_path: terraform/services/alarm-to-slack
+      sonar_project_key: cdap-alarm-to-slack

--- a/.github/workflows/alarm-to-slack-checks.yml
+++ b/.github/workflows/alarm-to-slack-checks.yml
@@ -1,4 +1,4 @@
-name: code-checks (set-log-retention-checks / cloudwatch log retention)
+name: code-checks (alarm-to-slack-checks)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/alarm-to-slack-test.yml
+++ b/.github/workflows/alarm-to-slack-test.yml
@@ -11,7 +11,7 @@ on:
     inputs:
       env:
         description: 'Environment (test, prod)'
-        required: true
+        required: false
         type: choice
         options:
           - test
@@ -19,7 +19,7 @@ on:
         default: 'test'
       state:
         description: 'Alarm state to set'
-        required: true
+        required: false
         type: choice
         options:
           - ALARM
@@ -33,7 +33,7 @@ on:
 
 jobs:
   trigger-alarm:
-    runs-on: codebuild-cdap-${{ inputs.env =='test' && 'non-prod' || 'prod' }}-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-cdap-${{ (inputs.env || (github.ref_name == 'main' && 'prod' || 'test')) == 'test' && 'non-prod' || 'prod' }}-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       id-token: write
       contents: read
@@ -42,23 +42,41 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ inputs.env == 'test' && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/cdap-${{ inputs.env == 'test' && 'non-prod' || 'prod' }}-github-actions
+          role-to-assume: arn:aws:iam::${{ (inputs.env || (github.ref_name == 'main' && 'prod' || 'test')) == 'test' && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/cdap-${{ (inputs.env || (github.ref_name == 'main' && 'prod' || 'test')) == 'test' && 'non-prod' || 'prod' }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
 
-
       - name: Set CloudWatch Alarm State
+        env:
+          ENV: ${{ inputs.env || (github.ref_name == 'main' && 'prod' || 'test') }}
+          STATE: ${{ inputs.state || 'ALARM' }}
+          REASON: ${{ inputs.reason || 'Automated test trigger via PR' }}
         run: |
-          ALARM_NAME="cdap-${{ inputs.env }}-test-alarm"
-          echo "Setting '${ALARM_NAME}' to '${{ inputs.state }}'..."
+          ALARM_NAME="cdap-${ENV}-test-alarm"
+          echo "Setting '${ALARM_NAME}' to '${STATE}'..."
 
           aws cloudwatch set-alarm-state \
             --alarm-name "${ALARM_NAME}" \
-            --state-value "${{ inputs.state }}" \
-            --state-reason "${{ inputs.reason }} at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            --state-value "${STATE}" \
+            --state-reason "${REASON} at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       - name: Verify Alarm State
+        env:
+          ENV: ${{ inputs.env || 'test' }}
+          STATE: ${{ inputs.state || 'ALARM' }}
         run: |
-          ALARM_NAME="cdap-${{ inputs.env }}-test-alarm"
+          ALARM_NAME="cdap-${ENV}-test-alarm"
           sleep 5
 
-          STATE
+          CURRENT_STATE=$(aws cloudwatch describe-alarms \
+            --alarm-names "${ALARM_NAME}" \
+            --query 'MetricAlarms[0].StateValue' \
+            --output text)
+
+          echo "Current alarm state: ${CURRENT_STATE}"
+
+          if [ "${CURRENT_STATE}" != "${STATE}" ]; then
+            echo "ERROR: Expected '${STATE}' but got '${CURRENT_STATE}'"
+            exit 1
+          fi
+
+          echo "Alarm state confirmed: ${CURRENT_STATE}. Check Slack for the notification."

--- a/.github/workflows/alarm-to-slack-test.yml
+++ b/.github/workflows/alarm-to-slack-test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ (inputs.env || (github.ref_name == 'main' && 'prod' || 'test')) == 'test' && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/cdap-${{ (inputs.env || (github.ref_name == 'main' && 'prod' || 'test')) == 'test' && 'non-prod' || 'prod' }}-github-actions
+          role-to-assume: arn:aws:iam::${{ (inputs.env || (github.ref_name == 'main' && 'prod' || 'test')) == 'test' && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/cdap-${{ (inputs.env || (github.ref_name == 'main' && 'prod' || 'test')) == 'test' && 'test' || 'prod' }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Set CloudWatch Alarm State

--- a/.github/workflows/alarm-to-slack-test.yml
+++ b/.github/workflows/alarm-to-slack-test.yml
@@ -1,0 +1,57 @@
+name: Trigger Test CloudWatch Alarm
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: 'Environment (test, prod)'
+        required: true
+        type: choice
+        options:
+          - test
+          - prod
+      state:
+        description: 'Alarm state to set'
+        required: true
+        type: choice
+        options:
+          - ALARM
+          - OK
+          - INSUFFICIENT_DATA
+        default: ALARM
+      reason:
+        description: 'Reason for state change (optional)'
+        required: false
+        default: 'Manual test trigger via GitHub Actions'
+
+jobs:
+  trigger-alarm:
+    runs-on: codebuild-cdap-${{ inputs.env =='test' && 'non-prod' || 'prod' }}-${{github.run_id}}-${{github.run_attempt}}
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ inputs.env == 'test' && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/cdap-${{ inputs.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+
+
+      - name: Set CloudWatch Alarm State
+        run: |
+          ALARM_NAME="cdap-${{ inputs.env }}-test-alarm"
+          echo "Setting '${ALARM_NAME}' to '${{ inputs.state }}'..."
+
+          aws cloudwatch set-alarm-state \
+            --alarm-name "${ALARM_NAME}" \
+            --state-value "${{ inputs.state }}" \
+            --state-reason "${{ inputs.reason }} at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+      - name: Verify Alarm State
+        run: |
+          ALARM_NAME="cdap-${{ inputs.env }}-test-alarm"
+          sleep 5
+
+          STATE

--- a/.github/workflows/alarm-to-slack-test.yml
+++ b/.github/workflows/alarm-to-slack-test.yml
@@ -1,6 +1,12 @@
 name: alarm-to-slack test trigger cloudwatch alarm
 
 on:
+  pull_request:
+    paths:
+      - 'terraform/services/alarm-to-slack/lambda_src/*.py'
+      - 'terraform/services/alarm-to-slack/lambda_src/requirements.txt'
+      - '.github/workflows/alarm-to-slack-checks.yml'
+      - '.github/workflows/checks-reusable.yml'
   workflow_dispatch:
     inputs:
       env:
@@ -10,6 +16,7 @@ on:
         options:
           - test
           - prod
+        default: test
       state:
         description: 'Alarm state to set'
         required: true

--- a/.github/workflows/alarm-to-slack-test.yml
+++ b/.github/workflows/alarm-to-slack-test.yml
@@ -1,4 +1,4 @@
-name: Trigger Test CloudWatch Alarm
+name: alarm-to-slack test trigger cloudwatch alarm
 
 on:
   workflow_dispatch:

--- a/.github/workflows/alarm-to-slack-test.yml
+++ b/.github/workflows/alarm-to-slack-test.yml
@@ -16,7 +16,7 @@ on:
         options:
           - test
           - prod
-        default: test
+        default: 'test'
       state:
         description: 'Alarm state to set'
         required: true
@@ -25,7 +25,7 @@ on:
           - ALARM
           - OK
           - INSUFFICIENT_DATA
-        default: ALARM
+        default: 'ALARM'
       reason:
         description: 'Reason for state change (optional)'
         required: false
@@ -42,7 +42,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ inputs.env == 'test' && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/cdap-${{ inputs.env }}-github-actions
+          role-to-assume: arn:aws:iam::${{ inputs.env == 'test' && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/cdap-${{ inputs.env == 'test' && 'non-prod' || 'prod' }}-github-actions
           aws-region: ${{ vars.AWS_REGION }}
 
 

--- a/.github/workflows/set-log-retention-checks.yml
+++ b/.github/workflows/set-log-retention-checks.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'scripts/set_log_retention/*.py'
       - 'scripts/set_log_retention/requirements.txt'
-      - 'terraform/modules/function/**'
       - '.github/workflows/set-log-retention-checks.yml'
       - '.github/workflows/checks-reusable.yml'
 

--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -126,24 +126,13 @@ resource "aws_cloudwatch_log_group" "function" {
 resource "aws_lambda_invocation" "liveness_check" {
   count         = var.liveness_check_enabled ? 1 : 0
   function_name = aws_lambda_function.this.function_name
-  qualifier     = aws_lambda_alias.live.name
 
   triggers = {
-    redeployment  = aws_lambda_function.this.source_code_hash
-    alias_version = aws_lambda_alias.live.function_version
+    redeployment = aws_lambda_function.this.source_code_hash
+    s3_version   = aws_lambda_function.this.s3_object_version
   }
 
   input = jsonencode({
     RequestType = "LivenessCheck"
   })
-
-  depends_on = [aws_lambda_alias.live]
-}
-
-resource "aws_lambda_alias" "live" {
-  name             = "live"
-  function_name    = aws_lambda_function.this.function_name
-  function_version = "$LATEST"
-
-  depends_on = [aws_lambda_function.this]
 }

--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -128,8 +128,7 @@ resource "aws_lambda_invocation" "liveness_check" {
   function_name = aws_lambda_function.this.function_name
 
   triggers = {
-    redeployment = aws_lambda_function.this.source_code_hash
-    s3_version   = aws_lambda_function.this.s3_object_version
+    s3_version = aws_lambda_function.this.s3_object_version
   }
 
   input = jsonencode({

--- a/terraform/modules/function/outputs.tf
+++ b/terraform/modules/function/outputs.tf
@@ -3,11 +3,6 @@ output "name" {
   value       = aws_lambda_function.this.function_name
 }
 
-output "alias_arn" {
-  description = "ARN of the live alias"
-  value       = aws_lambda_alias.live.arn
-}
-
 output "function_version" {
   description = "Active S3 object version ID used for the Lambda deployment package"
   value = var.rollback_version != null ? var.rollback_version : (var.source_dir != null ?

--- a/terraform/services/alarm-to-slack/lambda_src/lambda_function.py
+++ b/terraform/services/alarm-to-slack/lambda_src/lambda_function.py
@@ -53,7 +53,16 @@ def ping_slack_webhook(webhook, app, message_id=None):
     a broken webhook.
     """
     try:
-        jsondata = json.dumps({}).encode('utf-8')
+        payload = {
+            "AlarmDescription": "Liveness check — automated connectivity test",
+            "NewStateReason": "This is a deploy-time ping, not a real alarm state change",
+            "AlarmName": f"{app} — Liveness Check Ping",
+            "StateChangeTime": datetime.now().astimezone(tz=timezone.utc).isoformat(),
+            "NewStateValue": "LIVENESS_CHECK",
+            "Region": os.environ.get("AWS_REGION", "us-east-1"),
+            "OldStateValue": "LIVENESS_CHECK",
+        }
+        jsondata = json.dumps(payload).encode('utf-8')
         req = request.Request(webhook)
         req.add_header('Content-Type', 'application/json; charset=utf-8')
         req.add_header('Content-Length', str(len(jsondata)))
@@ -86,7 +95,7 @@ def liveness_check():
 
     Returns a dict with:
       - 'results': per-app status (ssm_ok, webhook_reachable)
-      - 'all_ok': True only if every app passed both checks
+      - 'all_ok': True if every app passed both checks
     """
     apps = get_app_list()
     if not apps:

--- a/terraform/services/alarm-to-slack/lambda_src/lambda_function.py
+++ b/terraform/services/alarm-to-slack/lambda_src/lambda_function.py
@@ -97,7 +97,7 @@ def liveness_check():
     all_ok = True
 
     for app in apps:
-        param_name = f'/{app}/lambda/slack_webhook_url'
+        param_name = f'/{app}/{env}/lambda/slack_webhook_url'
         webhook = get_ssm_parameter(param_name)
 
         ssm_ok = webhook is not None

--- a/terraform/services/alarm-to-slack/lambda_src/lambda_function.py
+++ b/terraform/services/alarm-to-slack/lambda_src/lambda_function.py
@@ -95,9 +95,9 @@ def liveness_check():
 
     results = {}
     all_ok = True
-
+    ssm_env = os.environ.get('SSM_ENV', '').lower()
     for app in apps:
-        param_name = f'/{app}/{env}/lambda/slack_webhook_url'
+        param_name = f'/{app}/{ssm_env}/lambda/slack_webhook_url'
         webhook = get_ssm_parameter(param_name)
 
         ssm_ok = webhook is not None
@@ -168,12 +168,14 @@ def lambda_handler(event, _):
         return handle_liveness_event(event)
 
     processed_count = 0
+    ssm_env = os.environ.get('SSM_ENV', '').lower()
+
     for record in event['Records']:
         message = enriched_cloudwatch_message(record)
         if message:
             app = message.get('App')
             if app:
-                webhook = get_ssm_parameter(f'/{app}/lambda/slack_webhook_url')
+                webhook = get_ssm_parameter(f'/{app}/{ssm_env}/lambda/slack_webhook_url')
                 if webhook:
                     send_message_to_slack(webhook, message, record.get('messageId'))
                     processed_count += 1

--- a/terraform/services/alarm-to-slack/main.tf
+++ b/terraform/services/alarm-to-slack/main.tf
@@ -72,31 +72,3 @@ module "platform" {
   service     = replace(basename(abspath(path.module)), "/^[0-9]+-/", "")
 }
 
-## CDAP Specific SNS topic
-resource "aws_sns_topic" "cloudwatch_alarms" {
-  name              = "${module.platform.app}-${module.platform.env}-cloudwatch-alarms"
-  kms_master_key_id = module.platform.kms_alias_primary.target_key_arn
-}
-
-resource "aws_sns_topic_subscription" "alarms_sqs" {
-  topic_arn = aws_sns_topic.cloudwatch_alarms.arn
-  protocol  = "sqs"
-  endpoint  = module.sns_to_slack_queue.arn
-}
-
-## Test cloudwatch metric alarm
-resource "aws_cloudwatch_metric_alarm" "test" {
-  alarm_name          = "${module.platform.app}-${module.platform.env}-test-alarm"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = 1
-  metric_name         = "TestMetric"
-  namespace           = "TestNamespace"
-  period              = 60
-  statistic           = "Sum"
-  threshold           = 1
-
-  alarm_description  = "Test alarm — use set-alarm-state to trigger manually"
-  alarm_actions      = [aws_sns_topic.cloudwatch_alarms.arn]
-  ok_actions         = [aws_sns_topic.cloudwatch_alarms.arn]
-  treat_missing_data = "missing" # Stays INSUFFICIENT_DATA, not ALARM
-}

--- a/terraform/services/alarm-to-slack/main.tf
+++ b/terraform/services/alarm-to-slack/main.tf
@@ -71,3 +71,32 @@ module "platform" {
   root_module = "https://github.com/CMSgov/cdap/tree/main/terraform/services/${basename(abspath(path.module))}/"
   service     = replace(basename(abspath(path.module)), "/^[0-9]+-/", "")
 }
+
+## CDAP Specific SNS topic
+resource "aws_sns_topic" "cloudwatch_alarms" {
+  name              = "${module.platform.app}-${module.platform.env}-cloudwatch-alarms"
+  kms_master_key_id = module.platform.kms_alias_primary.target_key_arn
+}
+
+resource "aws_sns_topic_subscription" "alarms_sqs" {
+  topic_arn = aws_sns_topic.cloudwatch_alarms.arn
+  protocol  = "sqs"
+  endpoint  = module.sns_to_slack_queue.arn
+}
+
+## Test cloudwatch metric alarm
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name          = "${module.platform.app}-${module.platform.env}-test-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "TestMetric"
+  namespace           = "TestNamespace"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+
+  alarm_description  = "Test alarm — use set-alarm-state to trigger manually"
+  alarm_actions      = [aws_sns_topic.cloudwatch_alarms.arn]
+  ok_actions         = [aws_sns_topic.cloudwatch_alarms.arn]
+  treat_missing_data = "missing" # Stays INSUFFICIENT_DATA, not ALARM
+}

--- a/terraform/services/alarm-to-slack/main.tf
+++ b/terraform/services/alarm-to-slack/main.tf
@@ -45,6 +45,7 @@ module "sns_to_slack_function" {
   environment_variables = {
     IGNORE_OK = true
     APPS      = join(",", var.apps_served)
+    SSM_ENV   = var.env
   }
 }
 

--- a/terraform/services/alarm-to-slack/test.tf
+++ b/terraform/services/alarm-to-slack/test.tf
@@ -1,18 +1,12 @@
 ## Use DPC platform module to use cross-team KMS keys
-module "dpc_platform" {
-  providers = { aws = aws, aws.secondary = aws.secondary }
-
-  source      = "../../modules/platform"
-  app         = "dpc"
-  env         = var.env
-  root_module = "https://github.com/CMSgov/cdap/tree/main/terraform/services/${basename(abspath(path.module))}/"
-  service     = replace(basename(abspath(path.module)), "/^[0-9]+-/", "")
+data "aws_kms_alias" "dpc" {
+  name = "alias/dpc-${var.env}"
 }
 
 ## DPC Test cloudwatch metric alarm
 resource "aws_sns_topic" "cloudwatch_alarms" {
   name              = "${module.platform.app}-${module.platform.env}-cloudwatch-alarms"
-  kms_master_key_id = module.dpc_platform.kms_alias_primary.target_key_arn
+  kms_master_key_id = data.aws_kms_alias.dpc.target_key_arn
 }
 
 resource "aws_sns_topic_subscription" "alarms_sqs" {

--- a/terraform/services/alarm-to-slack/test.tf
+++ b/terraform/services/alarm-to-slack/test.tf
@@ -1,0 +1,38 @@
+## Use DPC platform module to use cross-team KMS keys
+module "dpc_platform" {
+  providers = { aws = aws, aws.secondary = aws.secondary }
+
+  source      = "../../modules/platform"
+  app         = "dpc"
+  env         = var.env
+  root_module = "https://github.com/CMSgov/cdap/tree/main/terraform/services/${basename(abspath(path.module))}/"
+  service     = replace(basename(abspath(path.module)), "/^[0-9]+-/", "")
+}
+
+## DPC Test cloudwatch metric alarm
+resource "aws_sns_topic" "cloudwatch_alarms" {
+  name              = "${module.platform.app}-${module.platform.env}-cloudwatch-alarms"
+  kms_master_key_id = module.dpc_platform.kms_alias_primary.target_key_arn
+}
+
+resource "aws_sns_topic_subscription" "alarms_sqs" {
+  topic_arn = aws_sns_topic.cloudwatch_alarms.arn
+  protocol  = "sqs"
+  endpoint  = module.sns_to_slack_queue.arn
+}
+
+resource "aws_cloudwatch_metric_alarm" "test" {
+  alarm_name          = "${module.platform.app}-${module.platform.env}-test-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "TestMetric"
+  namespace           = "TestNamespace"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 1
+
+  alarm_description  = "Test alarm — use set-alarm-state to trigger manually"
+  alarm_actions      = [aws_sns_topic.cloudwatch_alarms.arn]
+  ok_actions         = [aws_sns_topic.cloudwatch_alarms.arn]
+  treat_missing_data = "missing" # Stays INSUFFICIENT_DATA, not ALARM
+}

--- a/terraform/services/github-actions-role/data.tf
+++ b/terraform/services/github-actions-role/data.tf
@@ -43,6 +43,11 @@ data "aws_kms_alias" "account_env_old_secondary" {
   name     = "alias/${local.account_env_old}"
 }
 
+data "aws_kms_alias" "all_managed_account_envs" {
+  for_each = toset(["ab2d", "dpc", "bcda"])
+  name     = "alias/${each.key}-${var.env}"
+}
+
 data "aws_kms_alias" "account_env" {
   name = "alias/${local.account_env}"
 }

--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -162,7 +162,8 @@ data "aws_iam_policy_document" "github_actions_policy" {
   # CloudWatch
   statement {
     actions = [
-      "cloudwatch:DescribeAlarms"
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:SetAlarmState"
     ]
     resources = ["*"]
   }

--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -328,6 +328,7 @@ data "aws_iam_policy_document" "github_actions_policy" {
         data.aws_kms_alias.bcda_app_config[*].target_key_arn,
         data.aws_kms_alias.bcda_insights_data_sampler[*].target_key_arn,
       ) : [],
+      var.app == "cdap" ? values(data.aws_kms_alias.all_managed_account_envs)[*].target_key_arn : [],
       var.app == "dpc" ? concat(
         data.aws_kms_alias.dpc_app_config[*].target_key_arn,
         data.aws_kms_alias.dpc_ecr[*].target_key_arn

--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -383,6 +383,7 @@ data "aws_iam_policy_document" "github_actions_policy" {
       "lambda:GetEventSourceMapping",
       "lambda:GetFunctionCodeSigningConfig",
       "lambda:GetPolicy",
+      "lambda:InvokeFunction",
       "lambda:ListTags",
       "lambda:ListVersionsByFunction",
       "lambda:TagResource",
@@ -471,6 +472,7 @@ data "aws_iam_policy_document" "github_actions_policy" {
       "s3:ListBucket",
       "s3:GetObject",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
       "s3:PutObject",
       "s3:DeleteObject"
     ]

--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -163,6 +163,7 @@ data "aws_iam_policy_document" "github_actions_policy" {
   statement {
     actions = [
       "cloudwatch:DescribeAlarms",
+      "cloudwatch:ListTagsForResource",
       "cloudwatch:SetAlarmState"
     ]
     resources = ["*"]

--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -350,6 +350,7 @@ data "aws_iam_policy_document" "github_actions_policy" {
       "iam:CreateRole",
       "iam:DeletePolicy",
       "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
       "iam:DetachRolePolicy",
       "iam:GetInstanceProfile",
       "iam:GetOpenIDConnectProvider",
@@ -460,6 +461,7 @@ data "aws_iam_policy_document" "github_actions_policy" {
       "s3:GetEncryptionConfiguration",
       "s3:GetLifecycleConfiguration",
       "s3:GetReplicationConfiguration",
+      "s3:ListBucket",
       "s3:PutBucketLogging",
       "s3:PutBucketNotification",
       "s3:PutBucketOwnershipControls",
@@ -468,8 +470,14 @@ data "aws_iam_policy_document" "github_actions_policy" {
       "s3:PutBucketVersioning",
       "s3:PutEncryptionConfiguration",
       "s3:PutLifecycleConfiguration",
+    ]
+    resources = ["*"]
+  }
+  # S3Objects
+  statement {
+    actions = [
+      "s3:ListObjectVersions",
       "s3:PutObjectTagging",
-      "s3:ListBucket",
       "s3:GetObject",
       "s3:GetObjectTagging",
       "s3:GetObjectVersion",


### PR DESCRIPTION
## 🎫 Ticket

PLT-1666

## 🛠 Changes
Adjusts permissions to enable retrieval of correct SSM parameters, set by SOPs, and application by github actions role. 

Creates test logic, first by setting up necessary alarm and SNS connection, and then by setting up a workflow that changes the state of that alarm to ensure connectivity end to end to slack. 

Also creates reusable checks logic to check code quality with sonarqube. 

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
These changes were validated by applying them in test and allowing the github workflow run. The slack message indicated the cloudwatch alarm was triggered and the slack webhook works. 

The changes to the github actions roles were applied for prod and will be tested by re-running the other application changes. 
<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
