### PR TITLE
PLT-1672 : Datadog Lambda Instrumentation

### DIFF
--- a/terraform/modules/function/README.md
+++ b/terraform/modules/function/README.md
@@ -13,6 +13,8 @@ This module provisions:
     An optional CloudWatch Events schedule trigger
     An optional deploy-time liveness check
     A live alias for stable invocation ARNs and rollback support
+    If var.dd_enabled = true, enables Datadog instrumentation for enhanced metrics and APM reporting via Datadog lambda layers. If false, uses the standard Lambda resource
+
 
 ### Cloudwatch Events 
     Pass a schedule_expression to enable a CloudWatch Events rule that invokes the function on a schedule. 

--- a/terraform/modules/function/iam.tf
+++ b/terraform/modules/function/iam.tf
@@ -68,6 +68,10 @@ data "aws_iam_policy_document" "function_assume_role" {
 
 data "aws_caller_identity" "current" {}
 
+data "aws_ssm_parameter" "dd_api_key" {
+  name = "/${local.app}/${local.env}/datadog/agents/api_key"
+}
+
 data "aws_iam_policy_document" "default_function" {
   dynamic "statement" {
     for_each = length(local.ssm_parameter_arns) > 0 ? [1] : []
@@ -77,7 +81,10 @@ data "aws_iam_policy_document" "default_function" {
         "ssm:GetParameter",
         "ssm:GetParameters",
       ]
-      resources = local.ssm_parameter_arns
+      resources = concat(
+        local.ssm_parameter_arns,
+        [data.aws_ssm_parameter.dd_api_key.arn]
+      )
     }
   }
 

--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -58,7 +58,27 @@ module "subnets" {
   vpc_id = module.vpc.id
 }
 
-resource "aws_lambda_function" "this" {
+module "lambda-datadog" {
+  source  = "DataDog/lambda-datadog/aws"
+  version = "4.7.0"
+
+  environment_variables = merge(var.environment_variables, {
+    "DD_API_KEY_SSM_ARN"          : data.aws_ssm_parameter.dd_api_key.arn
+    "DD_ENV"                      : local.env
+    "DD_SERVICE"                  : local.app
+    "DD_SITE"                     : "ddog-gov.com"
+    "DD_VERSION"                  : var.source_code_version
+    "DD_SERVERLESS_LOGS_ENABLED"  : false
+    "DD_LAMBDA_HANDLER"           : var.handler
+  })
+
+  datadog_extension_layer_version = 96
+  datadog_python_layer_version = startswith(var.runtime, "python") ? var.dd_python_layer_version : null
+  datadog_node_layer_version   = startswith(var.runtime, "nodejs") ? var.dd_node_layer_version : null
+  datadog_java_layer_version   = startswith(var.runtime, "java") ? var.dd_java_layer_version : null
+  datadog_ruby_layer_version   = startswith(var.runtime, "ruby") ? var.dd_ruby_layer_version : null
+  datadog_dotnet_layer_version = startswith(var.runtime, "dotnet") ? var.dd_dotnet_layer_version : null
+
   description   = var.description
   function_name = local.full_name_string
   s3_key        = "function.zip"
@@ -76,18 +96,9 @@ resource "aws_lambda_function" "this" {
   layers        = var.layer_arns
   architectures = [var.architecture]
 
-  tracing_config {
-    mode = "Active"
-  }
-
-  vpc_config {
-    subnet_ids         = module.subnets.ids
-    security_group_ids = [aws_security_group.function.id]
-  }
-
-  environment {
-    variables = var.environment_variables
-  }
+  tracing_config_mode = "Active"
+  vpc_config_subnet_ids         = module.subnets.ids
+  vpc_config_security_group_ids = [aws_security_group.function.id]
 }
 
 resource "aws_cloudwatch_event_rule" "this" {
@@ -101,7 +112,7 @@ resource "aws_cloudwatch_event_rule" "this" {
 resource "aws_cloudwatch_event_target" "this" {
   count = var.schedule_expression != "" ? 1 : 0
 
-  arn  = aws_lambda_function.this.arn
+  arn  = module.lambda-datadog.arn
   rule = aws_cloudwatch_event_rule.this[0].name
 }
 
@@ -110,7 +121,7 @@ resource "aws_lambda_permission" "cloudwatch_events" {
 
   statement_id  = "AllowExecutionFromCloudWatchEvents"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.this.function_name
+  function_name = module.lambda-datadog.function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.this[0].arn
 }
@@ -125,10 +136,10 @@ resource "aws_cloudwatch_log_group" "function" {
 
 resource "aws_lambda_invocation" "liveness_check" {
   count         = var.liveness_check_enabled ? 1 : 0
-  function_name = aws_lambda_function.this.function_name
+  function_name = module.lambda-datadog.function_name
 
   triggers = {
-    s3_version = aws_lambda_function.this.s3_object_version
+    s3_version = module.lambda-datadog.s3_object_version
   }
 
   input = jsonencode({

--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -4,6 +4,32 @@ locals {
   env             = var.platform.env
 
   full_name_string = "${local.app}-${local.env}-${var.name}"
+
+  # null = use latest S3 version; set = pin to a specific prior version
+  lambda_s3_object_version = var.rollback_version != null ? var.rollback_version : (var.source_dir != null ?
+  aws_s3_object.function_zip[0].version_id : var.source_code_version)
+
+  lambda_common = {
+    description       = var.description
+    function_name     = local.full_name_string
+    s3_key            = "function.zip"
+    s3_bucket         = module.zip_bucket.id
+    s3_object_version = local.lambda_s3_object_version
+    kms_key_arn       = var.platform.kms_alias_primary.target_key_arn
+    role              = aws_iam_role.function.arn
+    handler           = var.handler
+    runtime           = var.runtime
+    timeout           = var.timeout
+    memory_size       = var.memory_size
+    layers            = var.layer_arns
+    architectures     = [var.architecture]
+  }
+
+  lambda_function_arn              = var.dd_enabled ? module.lambda-datadog[0].arn : aws_lambda_function.this[0].arn
+  lambda_function_name             = var.dd_enabled ? module.lambda-datadog[0].function_name : aws_lambda_function.this[0].function_name
+  lambda_function_version          = var.dd_enabled ? module.lambda-datadog[0].version : aws_lambda_function.this[0].version
+  lambda_function_s3_version       = var.dd_enabled ? module.lambda-datadog[0].s3_object_version : aws_lambda_function.this[0].s3_object_version
+  lambda_function_source_code_hash = var.dd_enabled ? module.lambda-datadog[0].source_code_hash : aws_lambda_function.this[0].source_code_hash
 }
 
 # Only used when source_dir is provided
@@ -58,23 +84,62 @@ module "subnets" {
   vpc_id = module.vpc.id
 }
 
-resource "aws_lambda_function" "this" {
-  description   = var.description
-  function_name = local.full_name_string
-  s3_key        = "function.zip"
-  s3_bucket     = module.zip_bucket.id
-  # null = use latest S3 version; set = pin to a specific prior version
-  s3_object_version = var.rollback_version != null ? var.rollback_version : (var.source_dir != null ?
-  aws_s3_object.function_zip[0].version_id : var.source_code_version)
+module "lambda-datadog" {
+  count   = var.dd_enabled ? 1 : 0  # Only create if using Datadog Lambda module (var.dd_enabled = true)
+  source  = "DataDog/lambda-datadog/aws"
+  version = "4.7.0"
 
-  kms_key_arn   = var.platform.kms_alias_primary.target_key_arn
-  role          = aws_iam_role.function.arn
-  handler       = var.handler
-  runtime       = var.runtime
-  timeout       = var.timeout
-  memory_size   = var.memory_size
-  layers        = var.layer_arns
-  architectures = [var.architecture]
+  environment_variables = merge(var.environment_variables, {
+    "DD_API_KEY_SSM_ARN" : data.aws_ssm_parameter.dd_api_key.arn
+    "DD_ENV" : local.env
+    "DD_SERVICE" : local.app
+    "DD_SITE" : "ddog-gov.com"
+    "DD_VERSION" : var.source_code_version
+    "DD_SERVERLESS_LOGS_ENABLED" : false
+    "DD_LAMBDA_HANDLER" : var.handler
+  })
+
+  datadog_extension_layer_version = var.dd_extension_layer_version
+  datadog_python_layer_version    = startswith(var.runtime, "python") ? var.dd_python_layer_version : null
+  datadog_node_layer_version      = startswith(var.runtime, "nodejs") ? var.dd_node_layer_version : null
+  datadog_java_layer_version      = startswith(var.runtime, "java") ? var.dd_java_layer_version : null
+  datadog_ruby_layer_version      = startswith(var.runtime, "ruby") ? var.dd_ruby_layer_version : null
+  datadog_dotnet_layer_version    = startswith(var.runtime, "dotnet") ? var.dd_dotnet_layer_version : null
+
+  description       = local.lambda_common.description
+  function_name     = local.lambda_common.function_name
+  s3_key            = local.lambda_common.s3_key
+  s3_bucket         = local.lambda_common.s3_bucket
+  s3_object_version = local.lambda_common.s3_object_version
+  kms_key_arn       = local.lambda_common.kms_key_arn
+  role              = local.lambda_common.role
+  handler           = local.lambda_common.handler
+  runtime           = local.lambda_common.runtime
+  timeout           = local.lambda_common.timeout
+  memory_size       = local.lambda_common.memory_size
+  layers            = local.lambda_common.layers
+  architectures     = local.lambda_common.architectures
+
+  tracing_config_mode           = "Active"
+  vpc_config_subnet_ids         = module.subnets.ids
+  vpc_config_security_group_ids = [aws_security_group.function.id]
+}
+
+resource "aws_lambda_function" "this" {
+  count             = var.dd_enabled ? 0 : 1  # Only create if NOT using Datadog Lambda module (var.dd_enabled = false)
+  description       = local.lambda_common.description
+  function_name     = local.lambda_common.function_name
+  s3_key            = local.lambda_common.s3_key
+  s3_bucket         = local.lambda_common.s3_bucket
+  s3_object_version = local.lambda_common.s3_object_version
+  kms_key_arn       = local.lambda_common.kms_key_arn
+  role              = local.lambda_common.role
+  handler           = local.lambda_common.handler
+  runtime           = local.lambda_common.runtime
+  timeout           = local.lambda_common.timeout
+  memory_size       = local.lambda_common.memory_size
+  layers            = local.lambda_common.layers
+  architectures     = local.lambda_common.architectures
 
   tracing_config {
     mode = "Active"
@@ -101,7 +166,7 @@ resource "aws_cloudwatch_event_rule" "this" {
 resource "aws_cloudwatch_event_target" "this" {
   count = var.schedule_expression != "" ? 1 : 0
 
-  arn  = aws_lambda_function.this.arn
+  arn  = local.lambda_function_arn
   rule = aws_cloudwatch_event_rule.this[0].name
 }
 
@@ -110,7 +175,7 @@ resource "aws_lambda_permission" "cloudwatch_events" {
 
   statement_id  = "AllowExecutionFromCloudWatchEvents"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.this.function_name
+  function_name = local.lambda_function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.this[0].arn
 }
@@ -125,10 +190,10 @@ resource "aws_cloudwatch_log_group" "function" {
 
 resource "aws_lambda_invocation" "liveness_check" {
   count         = var.liveness_check_enabled ? 1 : 0
-  function_name = aws_lambda_function.this.function_name
+  function_name = local.lambda_function_name
 
   triggers = {
-    s3_version = aws_lambda_function.this.s3_object_version
+    s3_version = local.lambda_function_s3_version
   }
 
   input = jsonencode({

--- a/terraform/modules/function/outputs.tf
+++ b/terraform/modules/function/outputs.tf
@@ -9,6 +9,11 @@ output "function_version" {
   aws_s3_object.function_zip[0].version_id : var.source_code_version)
 }
 
+output "arn" {
+  description = "ARN of the Lambda function"
+  value       = module.lambda-datadog.arn
+}
+
 output "source_code_hash" {
   description = "Base64-encoded SHA256 hash of the Lambda deployment package"
   value       = module.lambda-datadog.source_code_hash

--- a/terraform/modules/function/outputs.tf
+++ b/terraform/modules/function/outputs.tf
@@ -1,6 +1,6 @@
 output "name" {
   description = "Name for the lambda function"
-  value       = aws_lambda_function.this.function_name
+  value       = module.lambda-datadog.function_name
 }
 
 output "function_version" {
@@ -11,7 +11,7 @@ output "function_version" {
 
 output "source_code_hash" {
   description = "Base64-encoded SHA256 hash of the Lambda deployment package"
-  value       = aws_lambda_function.this.source_code_hash
+  value       = module.lambda-datadog.source_code_hash
 }
 
 output "role_arn" {

--- a/terraform/modules/function/outputs.tf
+++ b/terraform/modules/function/outputs.tf
@@ -1,6 +1,6 @@
 output "name" {
   description = "Name for the lambda function"
-  value       = aws_lambda_function.this.function_name
+  value       = local.lambda_function_name
 }
 
 output "function_version" {
@@ -9,9 +9,14 @@ output "function_version" {
   aws_s3_object.function_zip[0].version_id : var.source_code_version)
 }
 
+output "arn" {
+  description = "ARN of the Lambda function alias (stable identifier for the active version)"
+  value       = local.lambda_function_arn
+}
+
 output "source_code_hash" {
   description = "Base64-encoded SHA256 hash of the Lambda deployment package"
-  value       = aws_lambda_function.this.source_code_hash
+  value       = local.lambda_function_source_code_hash
 }
 
 output "role_arn" {

--- a/terraform/modules/function/variables.tf
+++ b/terraform/modules/function/variables.tf
@@ -192,3 +192,45 @@ variable "github_actions_repos" {
   type        = list(string)
   default     = []
 }
+
+variable "dd_enabled" {
+  description = "If true, enables Datadog instrumentation for enhanced metrics and APM reporting via Datadog lambda layers. If false, use the standard Lambda resource."
+  type        = bool
+  default     = false
+}
+
+variable "dd_extension_layer_version" {
+  description = "Version number for Datadog's Lambda extension layer. Required if dd_enabled is true."
+  type        = number
+  default     = 96
+}
+
+variable "dd_python_layer_version" {
+  description = "Version number for Datadog's Python Lambda layer. Required if using a python runtime."
+  type        = number
+  default     = 125
+}
+
+variable "dd_node_layer_version" {
+  description = "Version number for Datadog's Node.js Lambda layer. Required if using a Node.js runtime."
+  type        = number
+  default     = 137
+}
+
+variable "dd_java_layer_version" {
+  description = "Version number for Datadog's Java Lambda layer. Required if using a Java runtime."
+  type        = number
+  default     = 26
+}
+
+variable "dd_ruby_layer_version" {
+  description = "Version number for Datadog's Ruby Lambda layer. Required if using a Ruby runtime."
+  type        = number
+  default     = 28
+}
+
+variable "dd_dotnet_layer_version" {
+  description = "Version number for Datadog's .NET Lambda layer. Required if using a .NET runtime."
+  type        = number
+  default     = 24
+}

--- a/terraform/modules/function/variables.tf
+++ b/terraform/modules/function/variables.tf
@@ -192,3 +192,33 @@ variable "github_actions_repos" {
   type        = list(string)
   default     = []
 }
+
+variable "dd_python_layer_version" {
+  description = "Version number for Datadog's Python Lambda layer. Required if using a python runtime."
+  type        = number
+  default     = 125
+}
+
+variable "dd_node_layer_version" {
+  description = "Version number for Datadog's Node.js Lambda layer. Required if using a Node.js runtime."
+  type        = number
+  default     = 137
+}
+
+variable "dd_java_layer_version" {
+  description = "Version number for Datadog's Java Lambda layer. Required if using a Java runtime."
+  type        = number
+  default     = 26
+}
+
+variable "dd_ruby_layer_version" {
+  description = "Version number for Datadog's Ruby Lambda layer. Required if using a Ruby runtime."
+  type        = number
+  default     = 28
+}
+
+variable "dd_dotnet_layer_version" {
+  description = "Version number for Datadog's .NET Lambda layer. Required if using a .NET runtime."
+  type        = number
+  default     = 24
+}

--- a/terraform/services/tftesting/function/main.tf
+++ b/terraform/services/tftesting/function/main.tf
@@ -19,6 +19,8 @@ resource "aws_ssm_parameter" "inline_policy_test" {
 module "tftesting_function" {
   source = "../../../modules/function"
 
+  dd_enabled = true # Set to true to test Datadog Lambda module integration
+
   platform    = module.platform
   name        = "tftesting"
   description = "Ephemeral Lambda for CI/CD integration testing — exercises module features"
@@ -58,7 +60,8 @@ module "tftesting_function" {
   github_actions_repos = []
 
   # Rollback support
-  rollback_version = "DDw7QokwqGuO4.kTDELfc_xWYg7B_73L" # null = track latest published version
+  #   rollback_version = "DDw7QokwqGuO4.kTDELfc_xWYg7B_73L" # null = track latest published version
+  rollback_version = null
 }
 
 

--- a/terraform/services/tftesting/function/outputs.tf
+++ b/terraform/services/tftesting/function/outputs.tf
@@ -5,7 +5,7 @@ output "function_name" {
 
 output "function_arn" {
   description = "ARN of the test Lambda function"
-  value       = module.tftesting_function.alias_arn
+  value       = module.tftesting_function.arn
 }
 
 output "function_version" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1672

## 🛠 Changes

Adds a Datadog lambda layer to to modules/function module to allow reporting of enhanced metrics and APM.

## ℹ️ Context

NewRelic is being sunset with a deadline of June 30, 2026. To support teams tracking infrastructure metrics/APM, we are switching to Datadog which has been provided by CMS.

## 🧪 Validation

Validated by deploying function, verifying DD layer is present, and verifying enhanced metrics and traces are displayed for the lambda in Datadog console.