### PR TITLE
BCDA-10120: Fix service name full skipping override

### DIFF
--- a/terraform/modules/service/main.tf
+++ b/terraform/modules/service/main.tf
@@ -1,6 +1,6 @@
 locals {
   service_name      = coalesce(var.service_name_override, var.platform.service)
-  service_name_full = "${var.platform.app}-${var.platform.env}-${coalesce(var.service_name_override, var.platform.service)}"
+  service_name_full = "${var.platform.app}-${var.platform.env}-${local.service_name}"
 
   # Build a name → containerPort lookup from port_mappings
   port_map = {

--- a/terraform/modules/service/main.tf
+++ b/terraform/modules/service/main.tf
@@ -1,6 +1,6 @@
 locals {
   service_name      = coalesce(var.service_name_override, var.platform.service)
-  service_name_full = "${var.platform.app}-${var.platform.env}-${var.platform.service}"
+  service_name_full = "${var.platform.app}-${var.platform.env}-${coalesce(var.service_name_override, var.platform.service)}"
 
   # Build a name → containerPort lookup from port_mappings
   port_map = {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10120

## 🛠 Changes

Changing service_name_full back to use service_name_override like it was a few revisions ago.

## ℹ️ Context

BCDA updated to the latest service module revision for Datadog integration work.  When planning in our dev env we noticed that it was trying to destroy a ton of our resources.  This seems to be the culprit.  Michael brings up a good point in that maybe we are using the platform module wrong.  Should we be creating multiple platform modules, one for each of our services?  Right now we are just setting up and using one: https://github.com/CMSgov/bcda-ops/blob/592d1d6bdbe6d30fd370fab1676303a3e03d02e8/terraform/dev/main.tf#L888.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
