### PR TITLE
BCDA-10120: Add service name with override as output

### DIFF
--- a/terraform/modules/service/outputs.tf
+++ b/terraform/modules/service/outputs.tf
@@ -8,6 +8,11 @@ output "ecs_service_name" {
   value       = aws_ecs_service.this.name
 }
 
+output "full_name_override" {
+  description = "Full name of the ECS service."
+  value       = local.service_name_full
+}
+
 output "ecs_service_id" {
   description = "ID of the ECS service."
   value       = aws_ecs_service.this.id


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10120

## 🛠 Changes

Add service name with override as output.

## ℹ️ Context

Recent changes to how service name was derived caused some issues with some of our resources.  In various places in `bcda-ops` we are referencing eg `service_name = module.ecs_ssas.service.name` which is returning `bcda-dev-bcda` (which previously returned ~`bcda-dev-api`).  Not sure if this is the most appropriate fix, all ears!

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

Local linting and workflow check.
