### PR TITLE
Switch from cmscloud.internal to internal.cms.gov. Establish hosted zone

### DIFF
--- a/terraform/modules/acm_certificate/data.tf
+++ b/terraform/modules/acm_certificate/data.tf
@@ -1,5 +1,5 @@
 locals {
-  hosted_zone_base_internal = "${var.platform.env}.${var.platform.app}.cmscloud.internal"
+  hosted_zone_base_internal = "${var.platform.env}.${var.platform.app}.internal.cms.gov"
   hosted_zone_base_zscaler  = "${var.platform.env}.${var.platform.app}.cmscloud.local"
 }
 

--- a/terraform/modules/acm_certificate/variables.tf
+++ b/terraform/modules/acm_certificate/variables.tf
@@ -19,9 +19,9 @@ variable "enable_internal_endpoint" {
   default     = false
   description = <<-EOT
     Issue a PCA-backed certificate for the VPC-internal endpoint.
-    Domain: <app>-<env>-<service>.internal.cms.gov
+    Domain: <service>.<env>.<app>.internal.cms.gov
     Use for Lambda/ECS-to-ECS calls that do not need Zscaler or public access.
-    Route 53 is NOT managed here — DNS for .internal.cms.gov is handled by CMS.
+    Route 53 is NOT managed here.
   EOT
 }
 
@@ -33,14 +33,14 @@ variable "enable_zscaler_endpoint" {
   default     = false
   description = <<-EOT
     Issue a PCA-backed certificate for the Zscaler-accessible endpoint.
-    Domain: <app>-<env>-<service>.cmscloud.local
+    Domain: <service>.<env>.<app>.cmscloud.local
     Route 53 is NOT managed here — DNS for cmscloud.local is handled by CMS.
 
     -------------------------------------------------------------------------
     CMS DOMAIN REGISTRATION — ACTION REQUIRED AFTER APPLY
     -------------------------------------------------------------------------
     After applying this module, submit a request to CMS to register:
-      <app>-<env>-<service>.cmscloud.local
+      <service>.<env>.<app>.cmscloud.local
     and point it at the ALB DNS name from the alb module output.
     Use the zscaler_domain output from this module for the request.
     -------------------------------------------------------------------------

--- a/terraform/modules/acm_certificate/variables.tf
+++ b/terraform/modules/acm_certificate/variables.tf
@@ -12,16 +12,16 @@ variable "platform" {
 }
 
 # -------------------------------------------------------
-# Internal endpoint (VPC-only, cmscloud.internal)
+# Internal endpoint (VPC-only, internal.cms.gov)
 # -------------------------------------------------------
 variable "enable_internal_endpoint" {
   type        = bool
   default     = false
   description = <<-EOT
     Issue a PCA-backed certificate for the VPC-internal endpoint.
-    Domain: <app>-<env>-<service>.internal
+    Domain: <app>-<env>-<service>.internal.cms.gov
     Use for Lambda/ECS-to-ECS calls that do not need Zscaler or public access.
-    Route 53 is NOT managed here — DNS for .internal is handled by CMS.
+    Route 53 is NOT managed here — DNS for .internal.cms.gov is handled by CMS.
   EOT
 }
 

--- a/terraform/services/hosted_zones/main.tf
+++ b/terraform/services/hosted_zones/main.tf
@@ -9,7 +9,7 @@ module "platform" {
 }
 
 resource "aws_route53_zone" "internal" {
-  name = "${var.env}.${var.app}.cmscloud.internal"
+  name = "${var.env}.${var.app}.internal.cms.gov"
 
   vpc {
     vpc_id = module.platform.vpc_id


### PR DESCRIPTION
Switch from cmscloud.internal to internal.cms.gov. Establish cdap hosted zone

## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1694

## 🛠 Changes

1. Update ACM Cert module to provision cert for internal.cms.gov instead of cmscloud.internal.
2. Update hosted zone service with internal.cms.gov also.

## ℹ️ Context

These changes will enable CDAP to host Datadog private locations to allow sythetic testing of API teams' private internal endpoints via Datadog Synthetics.

## 🧪 Validation

Changes will be validated after merge.
