### PR TITLE
BCDA-10060 Correct the repo string for function module trust policy

### DIFF
--- a/terraform/modules/function/iam.tf
+++ b/terraform/modules/function/iam.tf
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "function_assume_role" {
       condition {
         test     = "StringLike"
         variable = "${local.provider_domain}:sub"
-        values   = var.github_actions_repos
+        values   = [for repo in var.github_actions_repos : "repo:CMSgov/${repo}"]
       }
     }
   }

--- a/terraform/modules/function/variables.tf
+++ b/terraform/modules/function/variables.tf
@@ -186,7 +186,7 @@ variable "github_actions_repos" {
     function zip key.
 
     Example:
-      github_actions_repos = ["CMSgov/bcda-app", "CMSgov/dpc-app"]
+      github_actions_repos = ["bcda-app", "dpc-app"]
 
     Leave empty ([]) to disable CI/CD write access to the bucket entirely.
   EOT


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10060

## 🛠 Changes

added the prefix "repo:" to repositories named in assume role section of the trust policy

## ℹ️ Context

This change is needed to correct assume oidc errors for lambda codebuild.

## 🧪 Validation

See checks below.
