### PR TITLE
PLT-1715 Manage KMS access for external credentials (BB BFD)

### DIFF
--- a/terraform/services/410-external-kms/main.tf
+++ b/terraform/services/410-external-kms/main.tf
@@ -81,3 +81,36 @@ resource "aws_kms_alias" "shares" {
   name          = "alias/${each.value.app}-${each.value.env}"
   target_key_id = aws_kms_key.shares[each.key].key_id
 }
+
+resource "aws_secretsmanager_secret" "kms_key_arn" {
+  for_each    = local.kms_shares
+  name        = "/cdap/${each.value.app}/${each.value.env}/kms/key-arn"
+  description = "KMS key ARN for ${each.value.app} ${each.value.env} — for use in external account IAM policies"
+  kms_key_id  = aws_kms_alias.shares[each.key].target_key_arn
+}
+
+resource "aws_secretsmanager_secret_version" "kms_key_arn" {
+  for_each      = local.kms_shares
+  secret_id     = aws_secretsmanager_secret.kms_key_arn[each.key].id
+  secret_string = aws_kms_key.shares[each.key].arn
+}
+
+resource "aws_secretsmanager_secret_policy" "kms_key_arn" {
+  for_each   = local.kms_shares
+  secret_arn = aws_secretsmanager_secret.kms_key_arn[each.key].arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowExternalAccountRead"
+        Effect = "Allow"
+        Principal = {
+          AWS = data.aws_ssm_parameter.principal[each.value.principal_ssm_path].value
+        }
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = "*"
+      }
+    ]
+  })
+}

--- a/terraform/services/410-external-kms/main.tf
+++ b/terraform/services/410-external-kms/main.tf
@@ -108,7 +108,10 @@ resource "aws_secretsmanager_secret_policy" "kms_key_arn" {
         Principal = {
           AWS = data.aws_ssm_parameter.principal[each.value.principal_ssm_path].value
         }
-        Action   = "secretsmanager:GetSecretValue"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
         Resource = "*"
       }
     ]

--- a/terraform/services/410-external-kms/outputs.tf
+++ b/terraform/services/410-external-kms/outputs.tf
@@ -1,4 +1,5 @@
 output "kms_key_arns" {
+  sensitive   = true
   description = "Map of KMS key ARNs keyed by app-env"
   value = {
     for k, v in aws_kms_key.shares : k => v.arn
@@ -6,6 +7,7 @@ output "kms_key_arns" {
 }
 
 output "kms_key_arns_by_app" {
+  sensitive   = true
   description = "KMS key ARNs grouped by app name, then by env"
   value = {
     for app in distinct([for v in local.kms_shares : v.app]) :

--- a/terraform/services/501-datadog-cicd-keys/external.tf
+++ b/terraform/services/501-datadog-cicd-keys/external.tf
@@ -45,7 +45,7 @@ module "additional_datadog_application_key" {
 
 resource "aws_secretsmanager_secret" "datadog_application_key" {
   for_each    = local.cross_account_shares
-  name        = "${var.app}/${each.value.service}/${each.value.env}/datadog/cicd/application-key"
+  name        = "/${var.app}/${each.value.service}/${each.value.env}/datadog/cicd/application-key"
   description = "Datadog application key for ${each.value.service} ${each.value.env} — shared cross-account"
   kms_key_id  = data.aws_kms_alias.shares[each.key].target_key_arn
 
@@ -97,7 +97,7 @@ module "additional_datadog_api_key" {
 
 resource "aws_secretsmanager_secret" "datadog_api_key" {
   for_each    = local.cross_account_shares
-  name        = "${var.app}/${each.value.service}/${each.value.env}/datadog/cicd/api-key"
+  name        = "/${var.app}/${each.value.service}/${each.value.env}/datadog/cicd/api-key"
   description = "Datadog CICD API key for ${each.value.service} ${each.value.env} — shared cross-account"
   kms_key_id  = data.aws_kms_alias.shares[each.key].target_key_arn
 

--- a/terraform/services/503-datadog-agents-api-keys/external.tf
+++ b/terraform/services/503-datadog-agents-api-keys/external.tf
@@ -37,7 +37,7 @@ module "additional_datadog_api_key" {
 
 resource "aws_secretsmanager_secret" "datadog_api_key" {
   for_each    = local.cross_account_shares
-  name        = "${var.app}/${each.value.service}/${each.value.env}/datadog/agents/api-key"
+  name        = "/${var.app}/${each.value.service}/${each.value.env}/datadog/agents/api-key"
   description = "Datadog agents API key for ${each.value.service} ${each.value.env} — shared cross-account"
   kms_key_id  = data.aws_kms_alias.shares[each.key].target_key_arn
 


### PR DESCRIPTION


## 🎫 Ticket

PLT-1715

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Adds an additional secrets manager secret to ensure KMS key permissions can be configured per ECS service and Lambda by relevant teams using Datadog APM keys that are encrypted with KMS> 
## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
These changes were made to adjust to a permission'ing bug across the accounts. SSM was not used as 
1) RAM shares are not supported
2) While SSM Advanced tier does support resource-based policies, the Terraform AWS provider does not have a aws_ssm_parameter_policy resource. Applying the cross-account policy would have required using the AWS CLI or SDK — which is an anti-pattern for IAC use. 
3) The viable SSM-only path was an assumable IAM role in the BCDA account that the external account could assume to read the parameter. This added an extra provider block, role assumption step, and operational overhead that wasn't justified for sharing a non-sensitive value like a KMS key ARN.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
These changes were validated in tandem with BB who could successfully run their ECS service with an APM agent using the Datadog API Key and apply their Tofu as the primary user. Possible risks may arise as they use GitHub actions and their role there will need broad permissions to use KMS. 

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
