### PR TITLE
PLT-1717 : Explicitly manage Log Group for ECS Container Insights

### DIFF
--- a/terraform/modules/cloudwatch_log_group/README.md
+++ b/terraform/modules/cloudwatch_log_group/README.md
@@ -1,28 +1,3 @@
-# CDAP ECS Cluster Module 
-
-## Usage
-```hcl
-module "platform" {
-  source    = "github.com/CMSgov/cdap//terraform/modules/platform?ref=ff2ef539fb06f2c98f0e3ce0c8f922bdacb96d66"
-  providers = { aws = aws, aws.secondary = aws.secondary }
-
-  app         = "ab2d"
-  env         = "dev"
-  root_module = "https://github.com/CMSgov/ab2d/tree/main/ops/services/20-microservices"
-  service     = "contracts"
-  ssm_root_map = {
-    common = "/ab2d/${local.env}/common"
-    core   = "/ab2d/${local.env}/core"
-  }
-}
-
-module "cluster" {
-  source   = "github.com/CMSgov/cdap//terraform/modules/cluster?ref=<hash>"
-  platform = module.platform
-}
-
-```
-
 <!-- BEGIN_TF_DOCS -->
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
@@ -33,7 +8,7 @@ module "cluster" {
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
@@ -53,9 +28,9 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_platform"></a> [platform](#input\_platform) | Object that describes standardized platform values. | <pre>object({<br/>    app = string,<br/>    env = string,<br/>    kms_alias_primary = object({<br/>      target_key_arn = string<br/>    }),<br/>    service          = string,<br/>    is_ephemeral_env = string<br/>  })</pre> | n/a | yes |
-| <a name="input_cluster_name_override"></a> [cluster\_name\_override](#input\_cluster\_name\_override) | Name of the ecs cluster. | `string` | `null` | no |
-| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Number of days to retain ECS task logs in CloudWatch. Required for production is minimum 180. | `number` | `180` | no |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | ARN of the KMS key used to encrypt the log group. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the CloudWatch log group. | `string` | n/a | yes |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Number of days to retain logs in CloudWatch. Required for production is minimum 180. | `number` | `180` | no |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
@@ -64,9 +39,7 @@ No requirements.
 -->
 ## Modules
 
-| Name | Source | Version |
-| ---- | ------ | ------- |
-| <a name="module_ecs_container_insights_logs"></a> [ecs\_container\_insights\_logs](#module\_ecs\_container\_insights\_logs) | ../cloudwatch_log_group | n/a |
+No modules.
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
@@ -77,7 +50,7 @@ No requirements.
 
 | Name | Type |
 | ---- | ---- |
-| [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
@@ -88,5 +61,5 @@ No requirements.
 
 | Name | Description |
 | ---- | ----------- |
-| <a name="output_this"></a> [this](#output\_this) | The ecs cluster for the given inputs. |
+| <a name="output_this"></a> [this](#output\_this) | The CloudWatch log group. |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/cloudwatch_log_group/main.tf
+++ b/terraform/modules/cloudwatch_log_group/main.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name              = var.name
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_id
+}

--- a/terraform/modules/cloudwatch_log_group/outputs.tf
+++ b/terraform/modules/cloudwatch_log_group/outputs.tf
@@ -1,0 +1,4 @@
+output "this" {
+  description = "The CloudWatch log group."
+  value       = aws_cloudwatch_log_group.this
+}

--- a/terraform/modules/cloudwatch_log_group/variables.tf
+++ b/terraform/modules/cloudwatch_log_group/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  type        = string
+  description = "Name of the CloudWatch log group."
+}
+
+variable "kms_key_id" {
+  type        = string
+  description = "ARN of the KMS key used to encrypt the log group."
+}
+
+variable "log_retention_days" {
+  type        = number
+  default     = 180
+  description = "Number of days to retain logs in CloudWatch. Required for production is minimum 180."
+
+  validation {
+    condition = contains(
+      [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731,
+      1096, 1827, 2192, 2557, 2922, 3288, 3653],
+      var.log_retention_days
+    )
+    error_message = "log_retention_days must be a value supported by CloudWatch Logs (e.g. 30, 90, 180, 365, 731). See: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html"
+  }
+}

--- a/terraform/modules/cluster/README.md
+++ b/terraform/modules/cluster/README.md
@@ -24,36 +24,68 @@ module "cluster" {
 ```
 
 <!-- BEGIN_TF_DOCS -->
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
 ## Requirements
 
 No requirements.
 
-## Providers
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
+## Inputs
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_platform"></a> [platform](#input\_platform) | Object that describes standardized platform values. | <pre>object({<br/>    app = string,<br/>    env = string,<br/>    kms_alias_primary = object({<br/>      target_key_arn = string<br/>    }),<br/>    service          = string,<br/>    is_ephemeral_env = string<br/>  })</pre> | n/a | yes |
+| <a name="input_cluster_name_override"></a> [cluster\_name\_override](#input\_cluster\_name\_override) | Name of the ecs cluster. | `string` | `null` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Number of days to retain ECS task logs in CloudWatch. Required for production is minimum 180. | `number` | `180` | no |
 
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
 ## Modules
 
 No modules.
 
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
+| [aws_cloudwatch_log_group.ecs_container_insights_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_ecs_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
 
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_cluster_name_override"></a> [cluster\_name\_override](#input\_cluster\_name\_override) | Name of the ecs cluster. | `string` | `null` | no |
-| <a name="input_platform"></a> [platform](#input\_platform) | Object that describes standardized platform values. | `any` | n/a | yes |
-
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_this"></a> [this](#output\_this) | The ecs cluster for the given inputs. |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/cluster/main.tf
+++ b/terraform/modules/cluster/main.tf
@@ -1,10 +1,31 @@
+locals {
+  cluster_name = var.cluster_name_override != null ? var.cluster_name_override : "${var.platform.app}-${var.platform.env}-${var.platform.service}"
+}
+
+# CloudWatch Log Group for ECS Container Insights. If we don't manage this explicitly, it will be created automatically by AWS and we won't be able to manage the retention period via Terraform.
+resource "aws_cloudwatch_log_group" "ecs_container_insights_logs" {
+  name              = "/aws/ecs/containerinsights/${local.cluster_name}/performance"
+  retention_in_days = 180
+  kms_key_id        = var.platform.kms_alias_primary.target_key_arn
+
+  tags = {
+    Application = var.platform.app
+    Environment = var.platform.env
+    Service     = var.platform.service
+  }
+}
+
 resource "aws_ecs_cluster" "this" {
-  name = var.cluster_name_override != null ? var.cluster_name_override : "${var.platform.app}-${var.platform.env}-${var.platform.service}"
+  name = local.cluster_name
 
   setting {
     name  = "containerInsights"
     value = "enabled"
   }
+
+  depends_on = [
+    aws_cloudwatch_log_group.ecs_container_insights_logs
+  ]
 
   configuration {
     managed_storage_configuration {

--- a/terraform/modules/cluster/main.tf
+++ b/terraform/modules/cluster/main.tf
@@ -3,16 +3,11 @@ locals {
 }
 
 # CloudWatch Log Group for ECS Container Insights. If we don't manage this explicitly, it will be created automatically by AWS and we won't be able to manage the retention period via Terraform.
-resource "aws_cloudwatch_log_group" "ecs_container_insights_logs" {
-  name              = "/aws/ecs/containerinsights/${local.cluster_name}/performance"
-  retention_in_days = var.log_retention_days
-  kms_key_id        = var.platform.kms_alias_primary.target_key_arn
-
-  tags = {
-    Application = var.platform.app
-    Environment = var.platform.env
-    Service     = var.platform.service
-  }
+module "ecs_container_insights_logs" {
+  source             = "../cloudwatch_log_group"
+  name               = "/aws/ecs/containerinsights/${local.cluster_name}/performance"
+  log_retention_days = var.log_retention_days
+  kms_key_id         = var.platform.kms_alias_primary.target_key_arn
 }
 
 resource "aws_ecs_cluster" "this" {
@@ -24,7 +19,7 @@ resource "aws_ecs_cluster" "this" {
   }
 
   depends_on = [
-    aws_cloudwatch_log_group.ecs_container_insights_logs
+    module.ecs_container_insights_logs
   ]
 
   configuration {

--- a/terraform/modules/cluster/main.tf
+++ b/terraform/modules/cluster/main.tf
@@ -5,7 +5,7 @@ locals {
 # CloudWatch Log Group for ECS Container Insights. If we don't manage this explicitly, it will be created automatically by AWS and we won't be able to manage the retention period via Terraform.
 resource "aws_cloudwatch_log_group" "ecs_container_insights_logs" {
   name              = "/aws/ecs/containerinsights/${local.cluster_name}/performance"
-  retention_in_days = 180
+  retention_in_days = var.log_retention_days
   kms_key_id        = var.platform.kms_alias_primary.target_key_arn
 
   tags = {

--- a/terraform/modules/cluster/variables.tf
+++ b/terraform/modules/cluster/variables.tf
@@ -21,13 +21,4 @@ variable "log_retention_days" {
   type        = number
   default     = 180
   description = "Number of days to retain ECS task logs in CloudWatch. Required for production is minimum 180."
-
-  validation {
-    condition = contains(
-      [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731,
-      1096, 1827, 2192, 2557, 2922, 3288, 3653],
-      var.log_retention_days
-    )
-    error_message = "log_retention_days must be a value supported by CloudWatch Logs (e.g. 30, 90, 180, 365, 731). See: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html"
-  }
 }

--- a/terraform/modules/cluster/variables.tf
+++ b/terraform/modules/cluster/variables.tf
@@ -16,3 +16,18 @@ variable "cluster_name_override" {
   type        = string
   default     = null
 }
+
+variable "log_retention_days" {
+  type        = number
+  default     = 180
+  description = "Number of days to retain ECS task logs in CloudWatch. Required for production is minimum 180."
+
+  validation {
+    condition = contains(
+      [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731,
+      1096, 1827, 2192, 2557, 2922, 3288, 3653],
+      var.log_retention_days
+    )
+    error_message = "log_retention_days must be a value supported by CloudWatch Logs (e.g. 30, 90, 180, 365, 731). See: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html"
+  }
+}

--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -403,7 +403,6 @@ data "aws_iam_policy_document" "github_actions_policy" {
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
-      "logs:DeleteLogGroup",
       "logs:DescribeLogGroups",
       "logs:DescribeLogStreams",
       "logs:DescribeSubscriptionFilters",

--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -403,6 +403,7 @@ data "aws_iam_policy_document" "github_actions_policy" {
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
+      "logs:DeleteLogGroup",
       "logs:DescribeLogGroups",
       "logs:DescribeLogStreams",
       "logs:DescribeSubscriptionFilters",


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1717

## 🛠 Changes

terraform/modules/cluster/main.tf: added new log group ecs_container_insights_logs

## ℹ️ Context

We are required to retain logs for 180 days. Since Container Insights are enabled, if we don't manage this log group explicitly, it will be created automatically by AWS and we won't be able to set the retention period via Terraform.

## 🧪 Validation

Applied to test env and verified retention period is correctly set.
