### PR TITLE
PLT-1718 Support CDAP evaluation of alerts and alarms

### DIFF
--- a/terraform/services/530-cdap-datadog-monitors/config/prod.yml
+++ b/terraform/services/530-cdap-datadog-monitors/config/prod.yml
@@ -1,4 +1,4 @@
-shadow_mode: true
+shadow_mode: false
 
 notifications:
   victorops: true
@@ -7,9 +7,9 @@ lambda:
   error_rate_threshold: 1
 
 enabled:
-  ecs: false
-  sqs: false
+  ecs: true
+  sqs: true
   sns: false
-  lambda: false
+  lambda: true
   s3: false
   rds: false

--- a/terraform/services/530-cdap-datadog-monitors/config/test.yml
+++ b/terraform/services/530-cdap-datadog-monitors/config/test.yml
@@ -2,10 +2,10 @@ shadow_mode: false
 
 notifications:
   slack: true
-  victorops: true # for current testing
+  victorops: false
 
 enabled:
-  ecs: false
+  ecs: true
   sqs: true
   sns: false
   lambda: true


### PR DESCRIPTION
## 🎫 Ticket

PLT-1718

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Updates the CDAP Datadog monitors service configuration to enable additional monitor families and adjust notification/shadow-mode behavior to support alert/alarm evaluation.

Changes:

    Update test config to disable VictorOps notifications and enable ECS monitors.
    Update prod config to disable shadow_mode and enable ECS/SQS/Lambda monitor families.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
CDAP Dashboard now includes services under these AWS service categories, and CDAP is also used to test and evaluate monitors and dashboard, so its dashboard should be more inclusive. 
<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
