### PR TITLE
BB2-4951 add avg time per request graph to shared dashboard

### DIFF
--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -183,6 +183,38 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
 
         widget {
           timeseries_definition {
+            title = "Avg Time per Request"
+            live_span = var.widget_live_spans.apm
+            request {
+              display_type = "area"
+              query {
+                metric_query {
+                  name = "query1"
+                  query = "sum:trace.${var.apm_primary_operation}.exec_time.by_service{service:${var.app}, $env} by {sublayer_service, sublayer_inferred}.rollup(sum).fill(zero)"
+                }
+              }
+              query {
+                metric_query {
+                  name = "query2"
+                  query = "sum:trace.${var.apm_primary_operation}.hits{service:${var.app}, $env}.rollup(sum).fill(zero).as_count()"
+                }
+              }
+              formula {
+                formula_expression = "median_3(query1 / query2)"
+                number_format {
+                  unit {
+                    canonical {
+                      unit_name = "second"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        widget {
+          timeseries_definition {
             title     = "Error Rate"
             live_span = var.widget_live_spans.apm
             request {

--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -183,19 +183,19 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
 
         widget {
           timeseries_definition {
-            title = "Avg Time per Request"
+            title     = "Avg Time per Request"
             live_span = var.widget_live_spans.apm
             request {
               display_type = "area"
               query {
                 metric_query {
-                  name = "query1"
+                  name  = "query1"
                   query = "sum:trace.${var.apm_primary_operation}.exec_time.by_service{service:${var.app}, $env} by {sublayer_service, sublayer_inferred}.rollup(sum).fill(zero)"
                 }
               }
               query {
                 metric_query {
-                  name = "query2"
+                  name  = "query2"
                   query = "sum:trace.${var.apm_primary_operation}.hits{service:${var.app}, $env}.rollup(sum).fill(zero).as_count()"
                 }
               }


### PR DESCRIPTION

## 🎫 Ticket

BB2-4951

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Add a breakdown of average time per request to the shared dashboard.

Might need to update this to reflect the work in #518. One question then is, does the graph still make sense if it is filtered by application rather than by service?

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
This graph is visible on the APM service page, and breaks down average
time spent per request by service / its dependencies.

This is one of the graphs the Blue Button team had in New Relic, so replicating it here in the dashboard.

Counter / question: it's already on the service page, so is having it on the dashboard helpful?

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
needs validation, can deploy to bb dashboard and see if it works there
