### PR TITLE
Update BCDA view with new model info

### DIFF
--- a/terraform/services/insights/views/bcda/prod-entities-with-apm.view.sql
+++ b/terraform/services/insights/views/bcda/prod-entities-with-apm.view.sql
@@ -14,8 +14,9 @@ SELECT acos.cms_id,
         WHEN acos.cms_id ~ '^V\d{3}$' THEN 'NGACO'
         WHEN acos.cms_id ~ '^TEST\d{3}$' THEN 'TEST'
         WHEN acos.cms_id ~ '^CT\d{6}$' THEN 'MDTCOC'
-        WHEN acos.cms_id ~ '^GUIDE-\d{5}$' THEN 'GUIDE'
+        WHEN acos.cms_id ~ '^GUIDE-\d{4}$' THEN 'GUIDE'
         WHEN acos.cms_id ~ '^IOTA\d{3}$' THEN 'IOTA'
+        WHEN acos.cms_id ~ '^ACCES\d{5}$' THEN 'ACCESS' -- only one 's' due to character limits
         ELSE 'Other'
     END AS alternative_payment_model,
     (acos.termination_details->>'TerminationDate')::timestamptz AS termination_date

--- a/terraform/services/insights/views/bcda/prod-entities-with-apm.view.sql
+++ b/terraform/services/insights/views/bcda/prod-entities-with-apm.view.sql
@@ -7,18 +7,18 @@ SELECT acos.cms_id,
     CASE
         WHEN acos.cms_id ~ '^A\d{4}$' THEN 'SSP'
         WHEN acos.cms_id ~ '^DA\d{4}$' THEN 'CDAC'
-        WHEN acos.cms_id ~ '^D\d{4}$' THEN 'DC'
-        WHEN acos.cms_id ~ '^C\d{4}$' THEN 'CKCC'
-        WHEN acos.cms_id ~ '^K\d{4}$' THEN 'KCF'
+        WHEN acos.cms_id ~ '^D\d{4}$' THEN 'ACO REACH'
+        WHEN acos.cms_id ~ '^C\d{4}$' THEN 'KCC'
+        WHEN acos.cms_id ~ '^K\d{4}$' THEN 'KCC'
         WHEN acos.cms_id ~ '^E\d{4}$' THEN 'CEC'
         WHEN acos.cms_id ~ '^V\d{3}$' THEN 'NGACO'
         WHEN acos.cms_id ~ '^TEST\d{3}$' THEN 'TEST'
-        WHEN acos.cms_id ~ '^CT\d{6}$' THEN 'MDTCOC'
+        WHEN acos.cms_id ~ '^CT\d{6}$' THEN 'MD TCoC'
         WHEN acos.cms_id ~ '^GUIDE-\d{4}$' THEN 'GUIDE'
         WHEN acos.cms_id ~ '^IOTA\d{3}$' THEN 'IOTA'
         WHEN acos.cms_id ~ '^ACCES\d{5}$' THEN 'ACCESS' -- only one 's' due to character limits
         ELSE 'Other'
-    END AS alternative_payment_model,
+    END AS model_name,
     (acos.termination_details->>'TerminationDate')::timestamptz AS termination_date
 FROM acos
 WHERE acos.cms_id IS NOT NULL

--- a/terraform/services/insights/views/bcda/prod-jobs-with-cms-id.view.sql
+++ b/terraform/services/insights/views/bcda/prod-jobs-with-cms-id.view.sql
@@ -14,19 +14,20 @@ SELECT
     sq.benes_with_data,
     sq.benes_retrieved_percent,
     CASE
-        WHEN acos.cms_id ~ 'D\d{4}' THEN 'ACO REACH'
-        WHEN acos.cms_id ~ 'K\d{4}' THEN 'KCC'
-        WHEN acos.cms_id ~ 'C\d{4}' THEN 'KCC'
-        WHEN acos.cms_id ~ 'CT\d{6}' THEN 'MD TCoC'
-        WHEN acos.cms_id ~ '^A\d{4}' THEN 'SSP'
-        WHEN acos.cms_id ~ 'IOTA\d{3}' THEN 'IOTA'
-        WHEN acos.cms_id ~ 'GUIDE-\d{5}' THEN 'GUIDE'
-        WHEN acos.cms_id ~ 'DA\d{4}' THEN 'CDAC'
-        WHEN acos.cms_id ~ 'TEST\d{3}' THEN 'TEST'
-        WHEN acos.cms_id ~ 'V\d{3}' THEN 'NGACO'
-        WHEN acos.cms_id ~ 'E\d{4}' THEN 'CEC'
-        ELSE 'Unknown'
-    END AS model_name
+        WHEN acos.cms_id ~ '^A\d{4}$' THEN 'SSP'
+        WHEN acos.cms_id ~ '^DA\d{4}$' THEN 'CDAC'
+        WHEN acos.cms_id ~ '^D\d{4}$' THEN 'ACO REACH'
+        WHEN acos.cms_id ~ '^C\d{4}$' THEN 'KCC'
+        WHEN acos.cms_id ~ '^K\d{4}$' THEN 'KCC'
+        WHEN acos.cms_id ~ '^E\d{4}$' THEN 'CEC'
+        WHEN acos.cms_id ~ '^V\d{3}$' THEN 'NGACO'
+        WHEN acos.cms_id ~ '^TEST\d{3}$' THEN 'TEST'
+        WHEN acos.cms_id ~ '^CT\d{6}$' THEN 'MD TCoC'
+        WHEN acos.cms_id ~ '^GUIDE-\d{4}$' THEN 'GUIDE'
+        WHEN acos.cms_id ~ '^IOTA\d{3}$' THEN 'IOTA'
+        WHEN acos.cms_id ~ '^ACCES\d{5}$' THEN 'ACCESS' -- only one 's' due to character limits
+        ELSE 'Other'
+    END AS model_name,
 FROM jobs
 LEFT JOIN acos ON acos.uuid = jobs.aco_id
 JOIN (


### PR DESCRIPTION
For BCDA table views used in Quick, add the ACCESS model and correct the format used for GUIDE IDs

## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes
Updates the two production views that derive model_name from the CMS ID to:
1. Use consistent model names and logic
2. Use the corrected GUIDE model ID format (4 digits only)
3. Add the ACCESS model

## ℹ️ Context
BCDA has another new model ACCESS
BCDA has had a change in identifier for GUIDE, now only 4 digits like `GUIDE-####`

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
