### PR TITLE
BB2-4951 make the apdex widget have a timeseries in the background

### DIFF
--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -201,6 +201,12 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             request {
               q = "avg:trace.${var.apm_primary_operation}.apdex{service:${var.app}, $env}"
             }
+            timeseries_background {
+              type = "area"
+              yaxis {
+                include_zero = true
+              }
+            }
           }
         }
 


### PR DESCRIPTION

## 🎫 Ticket

BB2-4951

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Gives the apdex widget a timeseries background to give a little more information.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
A sudden drop in apdex would be useful to see. Could also consider just
making this a timeseries graph itself.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
needs validation, can test on bb dashboard
