### PR TITLE
BCDA-10269: update assertions schema +  support targetjsonpath

### DIFF
--- a/terraform/modules/datadog_synthetics/main.tf
+++ b/terraform/modules/datadog_synthetics/main.tf
@@ -20,6 +20,15 @@ resource "datadog_synthetics_test" "this" {
       operator = assertion.value.operator
       target   = assertion.value.target
       property = assertion.value.property
+
+      dynamic "targetjsonpath" {
+        for_each = assertion.value.targetjsonpath != null ? [assertion.value.targetjsonpath] : []
+        content {
+          jsonpath    = targetjsonpath.value.jsonpath
+          operator    = targetjsonpath.value.operator
+          targetvalue = targetjsonpath.value.targetvalue
+        }
+      }
     }
   }
 

--- a/terraform/modules/datadog_synthetics/variables.tf
+++ b/terraform/modules/datadog_synthetics/variables.tf
@@ -43,8 +43,13 @@ variable "tests" {
     assertions = list(object({
       type     = string
       operator = string
-      target   = string
+      target   = optional(string)
       property = optional(string)
+      targetjsonpath = optional(object({
+        jsonpath    = string
+        operator    = string
+        targetvalue = string
+      }))
     }))
 
     tick_every = optional(number, 60)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10269

## 🛠 Changes

- Updated `assertions` schema to make `target` optional and added `targetjsonpath` object structure for JSONPath assertions.
- Added a dynamic `targetjsonpath` block inside `assertion` to support `validatesJSONPath` checks.

## ℹ️ Context

For BCDA, we are validating whether the response object from the _health endpoint has `ok` status for all dependencies. This PR extends the functionality of the CDAP DD synthetics module.
