### PR TITLE
BB2-4971 fix missing shadow mode argument

### DIFF
--- a/terraform/services/530-cdap-datadog-monitors/synthetics.tf
+++ b/terraform/services/530-cdap-datadog-monitors/synthetics.tf
@@ -4,6 +4,8 @@ module "synthetics" {
   app = "cdap"
   env = var.env
 
+  shadow_mode = local.monitor_config.shadow_mode
+
   tests = {
     private_location_connectivity = {
       name    = "private-location-connectivity"


### PR DESCRIPTION
## 🎫 Ticket

BB2-4971

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Pass `shadow_mode` argument into the synthetics module where it is called.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
Without this passed in, `shadow_mode:false` will always be added to the
synthetics even if `shadow_mode` is actually true on the monitors.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Needs to be tested by someone on CDAP.
