### PR TITLE
BB2-4972 Output base_tags and non_private_location_ids

### DIFF
--- a/terraform/modules/datadog_synthetics/outputs.tf
+++ b/terraform/modules/datadog_synthetics/outputs.tf
@@ -1,9 +1,9 @@
-output "synthetics_tests" {
-  description = "List of {name, public_id} objects formatted for the datadog_monitors module's synthetics_tests input."
-  value = [
-    for key, test in datadog_synthetics_test.this : {
-      name      = test.name
-      public_id = test.id
-    }
-  ]
+output "base_tags" {
+  description = "Base tags applied to synthetics tests in this module."
+  value = local.base_tags
+}
+
+output "non_private_location_ids" {
+  description = "Datadog location IDs for all aws:us-gov* locations"
+  value = local.non_private_location_ids
 }

--- a/terraform/modules/datadog_synthetics/outputs.tf
+++ b/terraform/modules/datadog_synthetics/outputs.tf
@@ -1,9 +1,9 @@
 output "base_tags" {
   description = "Base tags applied to synthetics tests in this module."
-  value = local.base_tags
+  value       = local.base_tags
 }
 
 output "non_private_location_ids" {
   description = "Datadog location IDs for all aws:us-gov* locations"
-  value = local.non_private_location_ids
+  value       = local.non_private_location_ids
 }


### PR DESCRIPTION

## 🎫 Ticket

BB2-4972

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Output `base_tags` and `non_private_location_ids` so tests defined outside this module can use them.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
This allows teams to define synthetic tests resources themselves,
potentially using synthetic test options that this module does not yet
support.

Also, remove the `synthetic_tests` output, since it is no longer needed
as an input to the `datadog_monitors` module.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Just adds outputs, no validation needed.
