### PR TITLE
BCDA-10269: combine locations, eval min duration, add defaults

### DIFF
--- a/terraform/modules/datadog_synthetics/main.tf
+++ b/terraform/modules/datadog_synthetics/main.tf
@@ -33,11 +33,14 @@ resource "datadog_synthetics_test" "this" {
     }
   }
 
-  locations = each.value.use_private_location ? [local.private_location_id] : local.non_private_location_ids
+  locations = distinct(concat(
+    each.value.use_private_location && local.private_location_id != null ? [local.private_location_id] : (!each.value.use_private_location ? local.non_private_location_ids : []),
+    each.value.locations != null ? each.value.locations : []
+  ))
 
   lifecycle {
     precondition {
-      condition     = !each.value.use_private_location || local.private_location_id != null
+      condition     = !each.value.use_private_location || local.private_location_id != null || (each.value.locations != null && length(each.value.locations) > 0)
       error_message = "No Datadog private location found with prefix '${local.location_prefix}'. Verify the private location agent is registered for this environment."
     }
   }
@@ -45,7 +48,8 @@ resource "datadog_synthetics_test" "this" {
   options_list {
     tick_every           = each.value.tick_every
     monitor_name         = "[${upper(var.env)}] [${var.app}] Synthetics — ${each.value.name}"
-    min_failure_duration = var.min_failure_duration
+    min_failure_duration = try(coalesce(each.value.min_failure_duration, var.min_failure_duration), null)
+    min_location_failed  = each.value.min_location_failed
   }
 
   tags = concat(local.base_tags, each.value.tags)

--- a/terraform/modules/datadog_synthetics/main.tf
+++ b/terraform/modules/datadog_synthetics/main.tf
@@ -33,14 +33,11 @@ resource "datadog_synthetics_test" "this" {
     }
   }
 
-  locations = distinct(concat(
-    each.value.use_private_location && local.private_location_id != null ? [local.private_location_id] : (!each.value.use_private_location ? local.non_private_location_ids : []),
-    each.value.locations != null ? each.value.locations : []
-  ))
+  locations = each.value.use_private_location ? [local.private_location_id] : local.non_private_location_ids
 
   lifecycle {
     precondition {
-      condition     = !each.value.use_private_location || local.private_location_id != null || (each.value.locations != null && length(each.value.locations) > 0)
+      condition     = !each.value.use_private_location || local.private_location_id != null
       error_message = "No Datadog private location found with prefix '${local.location_prefix}'. Verify the private location agent is registered for this environment."
     }
   }
@@ -49,7 +46,6 @@ resource "datadog_synthetics_test" "this" {
     tick_every           = each.value.tick_every
     monitor_name         = "[${upper(var.env)}] [${var.app}] Synthetics — ${each.value.name}"
     min_failure_duration = try(coalesce(each.value.min_failure_duration, var.min_failure_duration), null)
-    min_location_failed  = each.value.min_location_failed
   }
 
   tags = concat(local.base_tags, each.value.tags)

--- a/terraform/modules/datadog_synthetics/variables.tf
+++ b/terraform/modules/datadog_synthetics/variables.tf
@@ -17,11 +17,13 @@ variable "shadow_mode" {
 variable "notify" {
   description = "Notify string from the monitors module."
   type        = string
+  default     = ""
 }
 
 variable "min_failure_duration" {
   description = "Minimum failure time to trigger alert in seconds. Should be set to the corresponding value from the monitor config passed to the monitors module."
   type        = number
+  default     = null
 }
 
 variable "tests" {
@@ -65,8 +67,11 @@ variable "tests" {
       }))
     }))
 
-    tick_every = optional(number, 60)
-    tags       = optional(list(string), [])
+    tick_every           = optional(number, 60)
+    min_failure_duration = optional(number)
+    min_location_failed  = optional(number)
+    locations            = optional(list(string))
+    tags                 = optional(list(string), [])
 
     use_private_location = optional(bool, true)
   }))

--- a/terraform/modules/datadog_synthetics/variables.tf
+++ b/terraform/modules/datadog_synthetics/variables.tf
@@ -17,13 +17,11 @@ variable "shadow_mode" {
 variable "notify" {
   description = "Notify string from the monitors module."
   type        = string
-  default     = ""
 }
 
 variable "min_failure_duration" {
   description = "Minimum failure time to trigger alert in seconds. Should be set to the corresponding value from the monitor config passed to the monitors module."
   type        = number
-  default     = null
 }
 
 variable "tests" {

--- a/terraform/modules/datadog_synthetics/variables.tf
+++ b/terraform/modules/datadog_synthetics/variables.tf
@@ -66,7 +66,7 @@ variable "tests" {
     }))
 
     tick_every           = optional(number, 60)
-    min_failure_duration = optional(number)
+    min_failure_duration = optional(number, null)
     tags                 = optional(list(string), [])
 
     use_private_location = optional(bool, true)

--- a/terraform/modules/datadog_synthetics/variables.tf
+++ b/terraform/modules/datadog_synthetics/variables.tf
@@ -67,8 +67,6 @@ variable "tests" {
 
     tick_every           = optional(number, 60)
     min_failure_duration = optional(number)
-    min_location_failed  = optional(number)
-    locations            = optional(list(string))
     tags                 = optional(list(string), [])
 
     use_private_location = optional(bool, true)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-10269

## 🛠 Changes

- Added optional `min_location_failed`, `min_failure_duration` fields to the `tests` variable schema
- Provided defaults in `variables.tf` so caller inputs remain optional

## ℹ️ Context

To prevent paging on single failures, BCDA requires a configurable minimum failure duration threshold before alerts trigger.
