### PR TITLE
AB2D-7247: SSM parameters for DB security group ID and endpoints

### DIFF
--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -21,12 +21,12 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_ssm_parameter" "db_security_group_id" {
-  name  = "/${var.platform.app}/${var.platform.env}/core/nonsensitive/db-security-group-id"
+  name  = "/${var.platform.app}/${var.platform.env}/aurora/nonsensitive/db-security-group-id"
   value = aws_security_group.this.id
   type  = "String"
 
   tags = {
-    Name = "/${var.platform.app}/${var.platform.env}/core/nonsensitive/db-security-group-id"
+    Name = "/${var.platform.app}/${var.platform.env}/aurora/nonsensitive/db-security-group-id"
   }
 }
 
@@ -175,4 +175,16 @@ resource "aws_rds_cluster_instance" "this" {
       performance_insights_retention_period,
     ]
   }
+}
+
+resource "aws_ssm_parameter" "writer_endpoint" {
+  name  = "/${var.platform.app}/${var.platform.env}/aurora/nonsensitive/writer-endpoint"
+  value = "${aws_rds_cluster.this.endpoint}:${aws_rds_cluster.this.port}"
+  type  = "String"
+}
+
+resource "aws_ssm_parameter" "reader_endpoint" {
+  name  = "/${var.platform.app}/${var.platform.env}/aurora/nonsensitive/reader-endpoint"
+  value = "${aws_rds_cluster.this.reader_endpoint}:${aws_rds_cluster.this.port}"
+  type  = "String"
 }

--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -20,6 +20,16 @@ resource "aws_security_group" "this" {
   }
 }
 
+resource "aws_ssm_parameter" "db_security_group_id" {
+  name  = "/${var.platform.app}/${var.platform.env}/core/nonsensitive/db-security-group-id"
+  value = aws_security_group.this.id
+  type  = "String"
+
+  tags = {
+    Name = "/${var.platform.app}/${var.platform.env}/core/nonsensitive/db-security-group-id"
+  }
+}
+
 resource "aws_vpc_security_group_egress_rule" "this" {
   cidr_ipv4         = "0.0.0.0/0"
   description       = "Allow all egress"

--- a/terraform/modules/aurora/variables.tf
+++ b/terraform/modules/aurora/variables.tf
@@ -38,7 +38,12 @@ variable "instance_count" {
 
 variable "vpc_security_group_ids" {
   default     = []
-  description = "Additional security group ids for attachment to the database security group."
+  description = <<-EOT
+    Deprecated. Additional security group IDs to attach directly to the Aurora cluster.
+    Service-level DB access should be granted via ingress rules referencing
+    the published SSM parameter at:
+    /${var.platform.app}/${var.platform.env}/aurora/nonsensitive/db-security-group-id
+  EOT
   type        = list(string)
 }
 


### PR DESCRIPTION
## 🎫 Ticket

AB2D-7247

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Moves SSM parameter publishing for Aurora cluster outputs into the module itself, so consumers have a predictable place to retrieve aurora information, including for security group rules configurations that live alongside terraservices. 

## ℹ️ Context
Consumers shouldn't need to know module internals or depend on caller terraservices to expose infrastructure values. IDR DB importer needs to know the security group information and writer endpoint and should not rely on ssm parameters generated in core for this - as they're commonly required. 

Enables the service-owned ingress rule pattern — services write their own DB ingress rules using the published SG ID rather than relying on a shared pre-created security group

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
