### PR TITLE
BB2-4929 Small ideas for monitors section of dashboard

### DIFF
--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -55,9 +55,9 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             sort                = "triggered,asc"
             summary_type        = "monitors"
 
-            # Note that $env must be unquoted here, because otherwise the * is
+            # Note that $environment must be unquoted here, because otherwise the * is
             # treated literally
-            query = "tag:\"application:${var.app}\" tag:$env status:alert"
+            query = "tag:\"application:${var.app}\" tag:$environment status:alert"
           }
         }
 
@@ -70,7 +70,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             show_last_triggered = true
             sort                = "status,asc"
             summary_type        = "monitors"
-            query               = "tag:\"application:${var.app}\" tag:$env"
+            query               = "tag:\"application:${var.app}\" tag:$environment"
           }
         }
       }

--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -54,9 +54,10 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             show_last_triggered = true
             sort                = "triggered,asc"
             summary_type        = "monitors"
+
             # Note that $env must be unquoted here, because otherwise the * is
             # treated literally
-            query               = "tag:\"application:${var.app}\" tag:$env status:alert"
+            query = "tag:\"application:${var.app}\" tag:$env status:alert"
           }
         }
 

--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -47,12 +47,12 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
 
         widget {
           manage_status_definition {
-            title               = "Alerting Monitors — ${var.app}"
+            title               = "Alerting Monitors"
             color_preference    = "text"
-            display_format      = "counts"
+            display_format      = "list"
             hide_zero_counts    = true
             show_last_triggered = true
-            sort                = "status,asc"
+            sort                = "triggered,asc"
             summary_type        = "monitors"
             query               = "tag:\"application:${var.app}\" status:alert"
           }
@@ -60,7 +60,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
 
         widget {
           manage_status_definition {
-            title               = "All Monitors — ${var.app}"
+            title               = "All Monitors"
             color_preference    = "text"
             display_format      = "counts"
             hide_zero_counts    = true

--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -54,7 +54,9 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             show_last_triggered = true
             sort                = "triggered,asc"
             summary_type        = "monitors"
-            query               = "tag:\"application:${var.app}\" status:alert"
+            # Note that $env must be unquoted here, because otherwise the * is
+            # treated literally
+            query               = "tag:\"application:${var.app}\" tag:$env status:alert"
           }
         }
 
@@ -67,7 +69,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             show_last_triggered = true
             sort                = "status,asc"
             summary_type        = "monitors"
-            query               = "tag:\"application:${var.app}\""
+            query               = "tag:\"application:${var.app}\" tag:$env"
           }
         }
       }


### PR DESCRIPTION
## 🎫 Ticket

BB2-4929

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Just a few small ideas for improvements.

- the alerting monitors count is replaced with a list
- The app name is no longer in the widget titles
- The monitor dashboard section now filters by environment so that it matches the behavior of the rest of the dashboard. Note that this does not appear to work when more than one environment is selected, and I'm not sure how to fix that.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Tested on Blue Button
