### PR TITLE
BB2-4929 Rename the env template variable to environment

### DIFF
--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -4,12 +4,12 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
 
   # -------------------------------------------------------
   # TEMPLATE VARIABLES
-  # $env     — filter by environment (e.g. dev, test, prod)
+  # $environment     — filter by environment (e.g. dev, test, prod)
   # $servicename — drill down to a specific ECS service
   #                (globally unique, e.g. cdap-test-tftesting-a)
   # -------------------------------------------------------
   template_variable {
-    name     = "env"
+    name     = "environment"
     prefix   = "environment"
     defaults = ["*"]
   }
@@ -26,7 +26,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
 
   widget {
     note_definition {
-      content          = "## ${upper(var.app)}\nMonitoring dashboard for all services under **${var.app}**.\n\nUse **$env** to filter by environment and **$servicename** to drill down to a specific service.\n\n[Runbook](${var.runbook_url}) | Alerts managed via Tofu monitors module"
+      content          = "## ${upper(var.app)}\nMonitoring dashboard for all services under **${var.app}**.\n\nUse **$environment** to filter by environment and **$servicename** to drill down to a specific service.\n\n[Runbook](${var.runbook_url}) | Alerts managed via Tofu monitors module"
       background_color = "blue"
       font_size        = "14"
       text_align       = "left"
@@ -164,7 +164,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             autoscale = true
             precision = 0
             request {
-              q = "clamp_min(sum:aws.ecs.service.desired{application:${var.app}, $env} by {servicename} - sum:aws.ecs.service.running{application:${var.app}, $env} by {servicename}, 0)"
+              q = "clamp_min(sum:aws.ecs.service.desired{application:${var.app}, $environment} by {servicename} - sum:aws.ecs.service.running{application:${var.app}, $environment} by {servicename}, 0)"
               conditional_formats {
                 comparator = ">"
                 value      = 0
@@ -190,7 +190,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Running Tasks by Service"
             live_span = var.widget_live_spans.current
             request {
-              q = "sum:aws.ecs.service.running{application:${var.app}, $env, $servicename} by {servicename}"
+              q = "sum:aws.ecs.service.running{application:${var.app}, $environment, $servicename} by {servicename}"
               conditional_formats {
                 comparator = "<"
                 value      = 1
@@ -210,7 +210,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Missing Tasks by Service (Desired - Running)"
             live_span = var.widget_live_spans.current
             request {
-              q = "clamp_min(sum:aws.ecs.service.desired{application:${var.app}, $env, $servicename} by {servicename} - sum:aws.ecs.service.running{application:${var.app}, $env, $servicename} by {servicename}, 0)"
+              q = "clamp_min(sum:aws.ecs.service.desired{application:${var.app}, $environment, $servicename} by {servicename} - sum:aws.ecs.service.running{application:${var.app}, $environment, $servicename} by {servicename}, 0)"
               conditional_formats {
                 comparator = ">"
                 value      = 0
@@ -230,7 +230,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Pending Tasks by Service"
             live_span = var.widget_live_spans.current
             request {
-              q = "sum:aws.ecs.service.pending{application:${var.app}, $env, $servicename} by {servicename}"
+              q = "sum:aws.ecs.service.pending{application:${var.app}, $environment, $servicename} by {servicename}"
               conditional_formats {
                 comparator = ">"
                 value      = 0
@@ -259,7 +259,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Container Restarts by Service"
             live_span = var.widget_live_spans.ecs
             request {
-              q            = "sum:container.restarts{application:${var.app}, $env} by {servicename}"
+              q            = "sum:container.restarts{application:${var.app}, $environment} by {servicename}"
               display_type = "bars"
               style {
                 palette = "warm"
@@ -272,7 +272,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
           event_stream_definition {
             title      = "ECS Task & Deployment Events"
             live_span  = var.widget_live_spans.ecs
-            query      = "source:amazon_ecs application:${var.app} $env $servicename"
+            query      = "source:amazon_ecs application:${var.app} $environment $servicename"
             event_size = "s"
           }
         }
@@ -289,7 +289,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "CPU Utilization by Service"
             live_span = var.widget_live_spans.ecs
             request {
-              q            = "avg:aws.ecs.cpuutilization{application:${var.app}, $env, $servicename} by {servicename}"
+              q            = "avg:aws.ecs.cpuutilization{application:${var.app}, $environment, $servicename} by {servicename}"
               display_type = "line"
             }
             marker {
@@ -310,7 +310,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Memory Utilization by Service"
             live_span = var.widget_live_spans.ecs
             request {
-              q            = "avg:aws.ecs.memory_utilization{application:${var.app}, $env, $servicename} by {servicename}"
+              q            = "avg:aws.ecs.memory_utilization{application:${var.app}, $environment, $servicename} by {servicename}"
               display_type = "line"
             }
             marker {
@@ -336,18 +336,18 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Network Throughput (kB/s) by Service"
             live_span = var.widget_live_spans.ecs
             request {
-              q            = "avg:container.net.rcvd{application:${var.app}, $env, $servicename} by {servicename}.as_rate()/1024"
+              q            = "avg:container.net.rcvd{application:${var.app}, $environment, $servicename} by {servicename}.as_rate()/1024"
               display_type = "line"
               metadata {
-                expression = "avg:container.net.rcvd{application:${var.app}, $env, $servicename} by {servicename}.as_rate()/1024"
+                expression = "avg:container.net.rcvd{application:${var.app}, $environment, $servicename} by {servicename}.as_rate()/1024"
                 alias_name = "kB/s In"
               }
             }
             request {
-              q            = "avg:container.net.sent{application:${var.app}, $env, $servicename} by {servicename}.as_rate()/1024"
+              q            = "avg:container.net.sent{application:${var.app}, $environment, $servicename} by {servicename}.as_rate()/1024"
               display_type = "line"
               metadata {
-                expression = "avg:container.net.sent{application:${var.app}, $env, $servicename} by {servicename}.as_rate()/1024"
+                expression = "avg:container.net.sent{application:${var.app}, $environment, $servicename} by {servicename}.as_rate()/1024"
                 alias_name = "kB/s Out"
               }
             }
@@ -364,18 +364,18 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Total Data Transferred (GB) by Service"
             live_span = var.widget_live_spans.ecs
             request {
-              q            = "sum:container.net.rcvd{application:${var.app}, $env, $servicename} by {servicename}/1073741824"
+              q            = "sum:container.net.rcvd{application:${var.app}, $environment, $servicename} by {servicename}/1073741824"
               display_type = "bars"
               metadata {
-                expression = "sum:container.net.rcvd{application:${var.app}, $env, $servicename} by {servicename}/1073741824"
+                expression = "sum:container.net.rcvd{application:${var.app}, $environment, $servicename} by {servicename}/1073741824"
                 alias_name = "GB In"
               }
             }
             request {
-              q            = "sum:container.net.sent{application:${var.app}, $env, $servicename} by {servicename}/1073741824"
+              q            = "sum:container.net.sent{application:${var.app}, $environment, $servicename} by {servicename}/1073741824"
               display_type = "bars"
               metadata {
-                expression = "sum:container.net.sent{application:${var.app}, $env, $servicename} by {servicename}/1073741824"
+                expression = "sum:container.net.sent{application:${var.app}, $environment, $servicename} by {servicename}/1073741824"
                 alias_name = "GB Out"
               }
             }
@@ -393,7 +393,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
           event_stream_definition {
             title      = "Task Events — Selected Service"
             live_span  = var.widget_live_spans.ecs
-            query      = "source:amazon_ecs application:${var.app} $env $servicename"
+            query      = "source:amazon_ecs application:${var.app} $environment $servicename"
             event_size = "l"
           }
         }
@@ -403,7 +403,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Container Restarts — Selected Service"
             live_span = var.widget_live_spans.ecs
             request {
-              q            = "sum:container.restarts{application:${var.app}, $env, $servicename} by {containername}"
+              q            = "sum:container.restarts{application:${var.app}, $environment, $servicename} by {containername}"
               display_type = "bars"
               style {
                 palette = "warm"
@@ -436,7 +436,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Request Rate by Service"
             live_span = var.widget_live_spans.apm
             request {
-              q            = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $env} by {service}.as_rate()"
+              q            = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $environment} by {service}.as_rate()"
               display_type = "line"
             }
           }
@@ -447,15 +447,15 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "p50 / p95 / p99 Latency"
             live_span = var.widget_live_spans.apm
             request {
-              q            = "p50:trace.${var.apm_primary_operation}{application:${var.app}, $env} by {service}"
+              q            = "p50:trace.${var.apm_primary_operation}{application:${var.app}, $environment} by {service}"
               display_type = "line"
             }
             request {
-              q            = "p95:trace.${var.apm_primary_operation}{application:${var.app}, $env} by {service}"
+              q            = "p95:trace.${var.apm_primary_operation}{application:${var.app}, $environment} by {service}"
               display_type = "line"
             }
             request {
-              q            = "p99:trace.${var.apm_primary_operation}{application:${var.app}, $env} by {service}"
+              q            = "p99:trace.${var.apm_primary_operation}{application:${var.app}, $environment} by {service}"
               display_type = "line"
             }
           }
@@ -470,13 +470,13 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
               query {
                 metric_query {
                   name  = "query1"
-                  query = "sum:trace.${var.apm_primary_operation}.exec_time.by_service{application:${var.app}, $env} by {sublayer_service, sublayer_inferred}.rollup(sum).fill(zero)"
+                  query = "sum:trace.${var.apm_primary_operation}.exec_time.by_service{application:${var.app}, $environment} by {sublayer_service, sublayer_inferred}.rollup(sum).fill(zero)"
                 }
               }
               query {
                 metric_query {
                   name  = "query2"
-                  query = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $env}.rollup(sum).fill(zero).as_count()"
+                  query = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $environment}.rollup(sum).fill(zero).as_count()"
                 }
               }
               formula {
@@ -498,7 +498,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Error Rate by Service"
             live_span = var.widget_live_spans.apm
             request {
-              q            = "sum:trace.${var.apm_primary_operation}.errors{application:${var.app}, $env} by {service}.as_rate()"
+              q            = "sum:trace.${var.apm_primary_operation}.errors{application:${var.app}, $environment} by {service}.as_rate()"
               display_type = "bars"
             }
           }
@@ -511,7 +511,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             autoscale = true
             precision = 2
             request {
-              q = "avg:trace.${var.apm_primary_operation}.apdex{application:${var.app}, $env}"
+              q = "avg:trace.${var.apm_primary_operation}.apdex{application:${var.app}, $environment}"
             }
             timeseries_background {
               type = "area"
@@ -542,7 +542,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Bucket Size (Bytes) by Bucket"
             live_span = var.widget_live_spans.s3
             request {
-              q = "avg:aws.s3.bucket_size_bytes{application:${var.app}, $env} by {bucketname}"
+              q = "avg:aws.s3.bucket_size_bytes{application:${var.app}, $environment} by {bucketname}"
             }
             style {
               display {
@@ -565,7 +565,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
                   aggregator  = "avg"
                   data_source = "metrics"
                   name        = "query1"
-                  query       = "avg:aws.s3.number_of_objects{application:${var.app}, $env} by {bucketname}"
+                  query       = "avg:aws.s3.number_of_objects{application:${var.app}, $environment} by {bucketname}"
                 }
               }
             }
@@ -596,7 +596,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Invocations by Function"
             live_span = var.widget_live_spans.lambda
             request {
-              q            = "sum:aws.lambda.invocations{application:${var.app}, $env} by {functionname}.as_count()"
+              q            = "sum:aws.lambda.invocations{application:${var.app}, $environment} by {functionname}.as_count()"
               display_type = "bars"
             }
           }
@@ -607,7 +607,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Duration (avg) by Function"
             live_span = var.widget_live_spans.lambda
             request {
-              q            = "avg:aws.lambda.duration{application:${var.app}, $env} by {functionname}"
+              q            = "avg:aws.lambda.duration{application:${var.app}, $environment} by {functionname}"
               display_type = "line"
             }
           }
@@ -618,7 +618,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Errors by Function"
             live_span = var.widget_live_spans.lambda
             request {
-              q            = "sum:aws.lambda.errors{application:${var.app}, $env} by {functionname}.as_count()"
+              q            = "sum:aws.lambda.errors{application:${var.app}, $environment} by {functionname}.as_count()"
               display_type = "bars"
             }
           }
@@ -629,7 +629,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Error Rate by Function (%)"
             live_span = var.widget_live_spans.lambda
             request {
-              q            = "sum:aws.lambda.errors{application:${var.app}, $env} by {functionname}.as_count() / sum:aws.lambda.invocations{application:${var.app}, $env} by {functionname}.as_count() * 100"
+              q            = "sum:aws.lambda.errors{application:${var.app}, $environment} by {functionname}.as_count() / sum:aws.lambda.invocations{application:${var.app}, $environment} by {functionname}.as_count() * 100"
               display_type = "line"
             }
           }
@@ -640,7 +640,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Throttles by Function"
             live_span = var.widget_live_spans.lambda
             request {
-              q            = "sum:aws.lambda.throttles{application:${var.app}, $env} by {functionname}.as_count()"
+              q            = "sum:aws.lambda.throttles{application:${var.app}, $environment} by {functionname}.as_count()"
               display_type = "bars"
             }
           }
@@ -651,7 +651,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Concurrent Executions by Function"
             live_span = var.widget_live_spans.lambda
             request {
-              q            = "avg:aws.lambda.concurrent_executions{application:${var.app}, $env} by {functionname}"
+              q            = "avg:aws.lambda.concurrent_executions{application:${var.app}, $environment} by {functionname}"
               display_type = "line"
             }
           }
@@ -677,7 +677,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Request Count by Target Group"
             live_span = var.widget_live_spans.alb
             request {
-              q            = "sum:aws.applicationelb.request_count{application:${var.app}, $env} by {targetgroup}.as_count()"
+              q            = "sum:aws.applicationelb.request_count{application:${var.app}, $environment} by {targetgroup}.as_count()"
               display_type = "bars"
             }
           }
@@ -688,7 +688,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Target Response Time p95 by Target Group"
             live_span = var.widget_live_spans.alb
             request {
-              q            = "avg:aws.applicationelb.target_response_time.p95{application:${var.app}, $env} by {targetgroup}"
+              q            = "avg:aws.applicationelb.target_response_time.p95{application:${var.app}, $environment} by {targetgroup}"
               display_type = "line"
             }
           }
@@ -699,7 +699,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Target HTTP 5XX by Target Group"
             live_span = var.widget_live_spans.alb
             request {
-              q            = "sum:aws.applicationelb.httpcode_target_5xx{application:${var.app}, $env} by {targetgroup}.as_count()"
+              q            = "sum:aws.applicationelb.httpcode_target_5xx{application:${var.app}, $environment} by {targetgroup}.as_count()"
               display_type = "bars"
             }
           }
@@ -710,7 +710,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Target HTTP 4XX by Target Group"
             live_span = var.widget_live_spans.alb
             request {
-              q            = "sum:aws.applicationelb.httpcode_target_4xx{application:${var.app}, $env} by {targetgroup}.as_count()"
+              q            = "sum:aws.applicationelb.httpcode_target_4xx{application:${var.app}, $environment} by {targetgroup}.as_count()"
               display_type = "bars"
             }
           }
@@ -721,7 +721,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Load Balancer HTTP 5XX by Load Balancer"
             live_span = var.widget_live_spans.alb
             request {
-              q            = "sum:aws.applicationelb.httpcode_elb_5xx{application:${var.app}, $env} by {loadbalancer}.as_count()"
+              q            = "sum:aws.applicationelb.httpcode_elb_5xx{application:${var.app}, $environment} by {loadbalancer}.as_count()"
               display_type = "bars"
             }
           }
@@ -732,7 +732,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Load Balancer HTTP 4XX by Load Balancer"
             live_span = var.widget_live_spans.alb
             request {
-              q            = "sum:aws.applicationelb.httpcode_elb_4xx{application:${var.app}, $env} by {loadbalancer}.as_count()"
+              q            = "sum:aws.applicationelb.httpcode_elb_4xx{application:${var.app}, $environment} by {loadbalancer}.as_count()"
               display_type = "bars"
             }
           }
@@ -743,7 +743,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Active Connection Count by Load Balancer"
             live_span = var.widget_live_spans.alb
             request {
-              q            = "sum:aws.applicationelb.active_connection_count{application:${var.app}, $env} by {loadbalancer}.as_count()"
+              q            = "sum:aws.applicationelb.active_connection_count{application:${var.app}, $environment} by {loadbalancer}.as_count()"
               display_type = "line"
             }
           }
@@ -754,11 +754,11 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Healthy vs Unhealthy Host Count by Target Group"
             live_span = var.widget_live_spans.alb
             request {
-              q            = "avg:aws.applicationelb.healthy_host_count{application:${var.app}, $env} by {targetgroup}"
+              q            = "avg:aws.applicationelb.healthy_host_count{application:${var.app}, $environment} by {targetgroup}"
               display_type = "line"
             }
             request {
-              q            = "avg:aws.applicationelb.un_healthy_host_count{application:${var.app}, $env} by {targetgroup}"
+              q            = "avg:aws.applicationelb.un_healthy_host_count{application:${var.app}, $environment} by {targetgroup}"
               display_type = "line"
             }
           }
@@ -784,7 +784,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Messages Visible by Queue"
             live_span = var.widget_live_spans.sqs
             request {
-              q            = "avg:aws.sqs.approximate_number_of_messages_visible{application:${var.app}, $env} by {queuename}"
+              q            = "avg:aws.sqs.approximate_number_of_messages_visible{application:${var.app}, $environment} by {queuename}"
               display_type = "line"
             }
           }
@@ -795,7 +795,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Dead Letter Queue Messages Visible"
             live_span = var.widget_live_spans.sqs
             request {
-              q            = "avg:aws.sqs.approximate_number_of_messages_visible{application:${var.app}, $env, queuename:*dlq*} by {queuename}"
+              q            = "avg:aws.sqs.approximate_number_of_messages_visible{application:${var.app}, $environment, queuename:*dlq*} by {queuename}"
               display_type = "bars"
             }
           }
@@ -806,7 +806,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Oldest Message Age (seconds) by Queue"
             live_span = var.widget_live_spans.sqs
             request {
-              q            = "max:aws.sqs.approximate_age_of_oldest_message{application:${var.app}, $env} by {queuename}"
+              q            = "max:aws.sqs.approximate_age_of_oldest_message{application:${var.app}, $environment} by {queuename}"
               display_type = "line"
             }
           }
@@ -817,11 +817,11 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Messages Sent / Deleted by Queue"
             live_span = var.widget_live_spans.sqs
             request {
-              q            = "sum:aws.sqs.number_of_messages_sent{application:${var.app}, $env} by {queuename}.as_count()"
+              q            = "sum:aws.sqs.number_of_messages_sent{application:${var.app}, $environment} by {queuename}.as_count()"
               display_type = "bars"
             }
             request {
-              q            = "sum:aws.sqs.number_of_messages_deleted{application:${var.app}, $env} by {queuename}.as_count()"
+              q            = "sum:aws.sqs.number_of_messages_deleted{application:${var.app}, $environment} by {queuename}.as_count()"
               display_type = "line"
             }
           }
@@ -847,15 +847,15 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Messages Published / Delivered / Failed by Topic"
             live_span = var.widget_live_spans.sns
             request {
-              q            = "sum:aws.sns.number_of_messages_published{application:${var.app}, $env} by {topicname}.as_count()"
+              q            = "sum:aws.sns.number_of_messages_published{application:${var.app}, $environment} by {topicname}.as_count()"
               display_type = "bars"
             }
             request {
-              q            = "sum:aws.sns.number_of_notifications_delivered{application:${var.app}, $env} by {topicname}.as_count()"
+              q            = "sum:aws.sns.number_of_notifications_delivered{application:${var.app}, $environment} by {topicname}.as_count()"
               display_type = "line"
             }
             request {
-              q            = "sum:aws.sns.number_of_notifications_failed{application:${var.app}, $env} by {topicname}.as_count()"
+              q            = "sum:aws.sns.number_of_notifications_failed{application:${var.app}, $environment} by {topicname}.as_count()"
               display_type = "bars"
             }
           }
@@ -866,7 +866,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Notification Failure Rate by Topic (%)"
             live_span = var.widget_live_spans.sns
             request {
-              q            = "sum:aws.sns.number_of_notifications_failed{application:${var.app}, $env} by {topicname}.as_count() / sum:aws.sns.number_of_messages_published{application:${var.app}, $env} by {topicname}.as_count() * 100"
+              q            = "sum:aws.sns.number_of_notifications_failed{application:${var.app}, $environment} by {topicname}.as_count() / sum:aws.sns.number_of_messages_published{application:${var.app}, $environment} by {topicname}.as_count() * 100"
               display_type = "line"
             }
           }
@@ -892,7 +892,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "DB Connections by Instance"
             live_span = var.widget_live_spans.aurora
             request {
-              q            = "avg:aws.rds.database_connections{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.database_connections{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
           }
@@ -903,7 +903,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "CPU Utilization by Instance"
             live_span = var.widget_live_spans.aurora
             request {
-              q            = "avg:aws.rds.cpuutilization{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.cpuutilization{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
           }
@@ -914,11 +914,11 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Read / Write Latency by Instance"
             live_span = var.widget_live_spans.aurora
             request {
-              q            = "avg:aws.rds.read_latency{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.read_latency{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
             request {
-              q            = "avg:aws.rds.write_latency{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.write_latency{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
           }
@@ -929,11 +929,11 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Read / Write IOPS by Instance"
             live_span = var.widget_live_spans.aurora
             request {
-              q            = "avg:aws.rds.read_iops{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.read_iops{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
             request {
-              q            = "avg:aws.rds.write_iops{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.write_iops{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
           }
@@ -944,7 +944,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Freeable Memory by Instance"
             live_span = var.widget_live_spans.aurora
             request {
-              q            = "avg:aws.rds.freeable_memory{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.freeable_memory{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
           }
@@ -955,7 +955,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Aurora Replica Lag by Instance"
             live_span = var.widget_live_spans.aurora
             request {
-              q            = "avg:aws.rds.aurora_replica_lag{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.aurora_replica_lag{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
           }
@@ -966,7 +966,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
             title     = "Estimated Shared Memory (Bytes) by Instance"
             live_span = var.widget_live_spans.aurora
             request {
-              q            = "avg:aws.rds.aurora_estimated_shared_memory_bytes{application:${var.app}, $env} by {dbinstanceidentifier}"
+              q            = "avg:aws.rds.aurora_estimated_shared_memory_bytes{application:${var.app}, $environment} by {dbinstanceidentifier}"
               display_type = "line"
             }
           }


### PR DESCRIPTION
## 🎫 Ticket

BB2-4929

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Rename the template variable `env` in the shared dashboard to `environment`.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
The tag it actually filters by is `environment`, so naming it the same
makes things clearer.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Tested on Blue Button.
