### PR TITLE
BB2-4929 Add error percentage widget

### DIFF
--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -518,7 +518,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
               query {
                 metric_query {
                   name  = "query2"
-                  query = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $env}.as_count()"
+                  query = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $env} by {service}.as_count()"
                 }
               }
               formula {

--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -505,6 +505,30 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
         }
 
         widget {
+          timeseries_definition {
+            title     = "Error Percentage by Service"
+            live_span = var.widget_live_spans.apm
+            request {
+              query {
+                metric_query {
+                  name  = "query1"
+                  query = "sum:trace.${var.apm_primary_operation}.errors{application:${var.app}, $env} by {service}.as_count()"
+                }
+              }
+              query {
+                metric_query {
+                  name  = "query2"
+                  query = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $env}.as_count()"
+                }
+              }
+              formula {
+                formula_expression = "query1 / query2"
+              }
+            }
+          }
+        }
+
+        widget {
           query_value_definition {
             title     = "Apdex Score"
             live_span = var.widget_live_spans.current

--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -524,6 +524,7 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
               formula {
                 formula_expression = "query1 / query2"
               }
+              display_type = "bars"
             }
           }
         }

--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -512,13 +512,13 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
               query {
                 metric_query {
                   name  = "query1"
-                  query = "sum:trace.${var.apm_primary_operation}.errors{application:${var.app}, $env} by {service}.as_count()"
+                  query = "sum:trace.${var.apm_primary_operation}.errors{application:${var.app}, $environment} by {service}.as_count()"
                 }
               }
               query {
                 metric_query {
                   name  = "query2"
-                  query = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $env} by {service}.as_count()"
+                  query = "sum:trace.${var.apm_primary_operation}.hits{application:${var.app}, $environment} by {service}.as_count()"
                 }
               }
               formula {


### PR DESCRIPTION
## 🎫 Ticket

BB2-4929

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Add a widget that displays APM error percentage

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
The existing error rate is errors/second, this is errors as a percentage
of all hits.

This was asked for by our tech lead.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Tested on Blue Button
