### PR TITLE
PLT-1720 Add mTLS sidecar support as private cert option

### DIFF
--- a/terraform/modules/acm_certificate/README.md
+++ b/terraform/modules/acm_certificate/README.md
@@ -1,3 +1,44 @@
+Issues and manages ACM certificates for CMS platform services.
+Supports three certificate paths: PCA-backed private certificates
+(internal endpoints, Zscaler endpoints, mTLS sidecars) and
+CMS-signed public certificates (*.cms.gov).
+
+
+## Design Decisions
+
+- **Explicit instantiation required.** This module is never called
+  internally by `ecs_service`, `alb`, or other consumer modules.
+  All ACM certificates are top-level resources in the caller stack,
+  making them easy to audit via `tofu state list`.
+- **mTLS passphrase is ephemeral.** The mTLS sidecar generates a
+  one-time passphrase in memory at container startup, uses it to
+  decrypt the exported cert bundle to tmpfs, and discards it.
+  No passphrase is stored in SSM or state.
+- **One private cert, multiple consumers.** When both
+  `enable_internal_endpoint` and `enable_mtls_sidecar` are true,
+  both outputs resolve to the same underlying cert. The separate
+  output names exist for caller clarity only.
+
+## Zscaler Registration — Action Required
+
+Setting enable_zscaler_endpoint = true does not automatically register the domain. After applying, submit a DNS registration request to the CMS network team for:
+
+<service>.<env>.<app>.cmscloud.local
+
+## Public Certificate Process
+
+1. Apply with `public_domain_name` set but without `public_certificate`
+   or `public_private_key`.
+2. Retrieve the CSR from SSM:
+   `/<app>/<env>/<service>/tls/v1/csr`
+3. Submit the CSR to CMS for signing.
+4. Encrypt the returned cert, key, and chain via SOPS.
+5. Pass the SOPS-decrypted values into `public_certificate`,
+   `public_private_key`, and `public_certificate_chain`.
+6. Re-apply — the cert is imported into ACM automatically.
+
+
+
 <!-- BEGIN_TF_DOCS -->
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
      'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
@@ -34,8 +75,9 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_platform"></a> [platform](#input\_platform) | Object representing the CDAP platform module. | <pre>object({<br/>    app            = string<br/>    env            = string<br/>    primary_region = object({ name = string })<br/>    service        = string<br/>    kms_alias_primary = object({<br/>      target_key_arn = string<br/>    })<br/>  })</pre> | n/a | yes |
-| <a name="input_enable_internal_endpoint"></a> [enable\_internal\_endpoint](#input\_enable\_internal\_endpoint) | Issue a PCA-backed certificate for the VPC-internal endpoint.<br/>Domain: <app>-<env>-<service>.internal<br/>Use for Lambda/ECS-to-ECS calls that do not need Zscaler or public access.<br/>Route 53 is NOT managed here — DNS for .internal is handled by CMS. | `bool` | `false` | no |
-| <a name="input_enable_zscaler_endpoint"></a> [enable\_zscaler\_endpoint](#input\_enable\_zscaler\_endpoint) | Issue a PCA-backed certificate for the Zscaler-accessible endpoint.<br/>Domain: <app>-<env>-<service>.cmscloud.local<br/>Route 53 is NOT managed here — DNS for cmscloud.local is handled by CMS.<br/><br/>-------------------------------------------------------------------------<br/>CMS DOMAIN REGISTRATION — ACTION REQUIRED AFTER APPLY<br/>-------------------------------------------------------------------------<br/>After applying this module, submit a request to CMS to register:<br/>  <app>-<env>-<service>.cmscloud.local<br/>and point it at the ALB DNS name from the alb module output.<br/>Use the zscaler\_domain output from this module for the request.<br/>------------------------------------------------------------------------- | `bool` | `false` | no |
+| <a name="input_enable_internal_endpoint"></a> [enable\_internal\_endpoint](#input\_enable\_internal\_endpoint) | Issue a PCA-backed certificate for the VPC-internal endpoint.<br/>Domain: <service>.<env>.<app>.internal.cms.gov<br/>Use for Lambda/ECS-to-ECS calls that do not need Zscaler or public access.<br/>Route 53 is NOT managed here. | `bool` | `false` | no |
+| <a name="input_enable_mtls_sidecar"></a> [enable\_mtls\_sidecar](#input\_enable\_mtls\_sidecar) | Issue a PCA-backed certificate for mTLS between the ALB and the sidecar container.<br/>This certificate is NOT accessed by developers via Zscaler — it is used internally<br/>between the ALB and ECS sidecar only.<br/>Domain: <service>.<env>.<app>.internal.cms.gov (same as internal endpoint). | `bool` | `false` | no |
+| <a name="input_enable_zscaler_endpoint"></a> [enable\_zscaler\_endpoint](#input\_enable\_zscaler\_endpoint) | Issue a PCA-backed certificate for the Zscaler-accessible endpoint.<br/>Domain: <service>.<env>.<app>.cmscloud.local<br/>Route 53 is NOT managed here — DNS for cmscloud.local is handled by CMS.<br/><br/>-------------------------------------------------------------------------<br/>CMS DOMAIN REGISTRATION — ACTION REQUIRED AFTER APPLY<br/>-------------------------------------------------------------------------<br/>After applying this module, submit a request to CMS to register:<br/>  <service>.<env>.<app>.cmscloud.local<br/>and point it at the ALB DNS name from the alb module output.<br/>Use the zscaler\_domain output from this module for the request.<br/>------------------------------------------------------------------------- | `bool` | `false` | no |
 | <a name="input_pca_ram_resource_share_name"></a> [pca\_ram\_resource\_share\_name](#input\_pca\_ram\_resource\_share\_name) | Name of the AWS RAM resource share providing access to the shared Private CA. Required when enable\_internal\_endpoint or enable\_zscaler\_endpoint is true. | `string` | `"pace-ca-g1"` | no |
 | <a name="input_public_certificate"></a> [public\_certificate](#input\_public\_certificate) | PEM-encoded CMS-signed public certificate. Include via SOPS if provided by CMS. Set null to defer import while awaiting CMS signing. | `string` | `null` | no |
 | <a name="input_public_certificate_chain"></a> [public\_certificate\_chain](#input\_public\_certificate\_chain) | PEM-encoded certificate chain. Optional — include via SOPS if provided by CMS with the signed certificate. | `string` | `null` | no |
@@ -63,7 +105,6 @@ No modules.
 |------|------|
 | [aws_acm_certificate.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
 | [aws_acm_certificate.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
-| [aws_acm_certificate_validation.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
 | [aws_ssm_parameter.csr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [tls_cert_request.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
@@ -82,8 +123,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_csr_retrieval_instructions"></a> [csr\_retrieval\_instructions](#output\_csr\_retrieval\_instructions) | Instructions for retrieving the latest CSR and submitting to CMS. |
-| <a name="output_internal_domain"></a> [internal\_domain](#output\_internal\_domain) | n/a |
-| <a name="output_private_certificate_arn"></a> [private\_certificate\_arn](#output\_private\_certificate\_arn) | ARN of the PCA-issued certificate covering the internal and/or zscaler domains. Use as the primary cert on the ALB HTTPS listener. |
-| <a name="output_public_certificate_arn"></a> [public\_certificate\_arn](#output\_public\_certificate\_arn) | ARN of the imported CMS-signed public certificate. Null if cert values have not yet been provided. |
+| <a name="output_internal_domain"></a> [internal\_domain](#output\_internal\_domain) | FQDN of the internal endpoint. Use this as the Route 53 record name for DNS record to match exactly. |
+| <a name="output_private_cert_arn"></a> [private\_cert\_arn](#output\_private\_cert\_arn) | ARN of the PCA-issued certificate covering the internal and/or zscaler domains. Use as the primary cert on the ALB HTTPS listener. |
+| <a name="output_public_cert_arn"></a> [public\_cert\_arn](#output\_public\_cert\_arn) | ARN of the imported CMS-signed public certificate. Null if cert values have not yet been provided. |
 | <a name="output_zscaler_domain"></a> [zscaler\_domain](#output\_zscaler\_domain) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/modules/acm_certificate/data.tf
+++ b/terraform/modules/acm_certificate/data.tf
@@ -4,13 +4,13 @@ locals {
 }
 
 data "aws_ram_resource_share" "pace_ca" {
-  count          = (var.enable_internal_endpoint || var.enable_zscaler_endpoint) ? 1 : 0
+  count          = local.needs_private_cert ? 1 : 0
   resource_owner = "OTHER-ACCOUNTS"
   name           = var.pca_ram_resource_share_name
 }
 
 data "aws_route53_zone" "internal" {
-  count        = var.enable_internal_endpoint ? 1 : 0
+  count        = (var.enable_internal_endpoint || var.enable_mtls_sidecar) ? 1 : 0
   name         = local.hosted_zone_base_internal
   private_zone = true
 }

--- a/terraform/modules/acm_certificate/main.tf
+++ b/terraform/modules/acm_certificate/main.tf
@@ -1,29 +1,37 @@
 locals {
-  internal_domain = var.enable_internal_endpoint ? "${var.platform.service}.${trimsuffix(data.aws_route53_zone.internal[0].name, ".")}" : null
-  zscaler_domain  = var.enable_zscaler_endpoint ? "${var.platform.service}.${trimsuffix(data.aws_route53_zone.zscaler[0].name, ".")}" : null
+  internal_domain = (var.enable_internal_endpoint || var.enable_mtls_sidecar) ? (
+    "${var.platform.service}.${trimsuffix(data.aws_route53_zone.internal[0].name, ".")}"
+  ) : null
+  zscaler_domain = var.enable_zscaler_endpoint ? "${var.platform.service}.${trimsuffix(data.aws_route53_zone.zscaler[0].name, ".")}" : null
 
-  private_primary_domain = (
-    var.enable_internal_endpoint ? local.internal_domain :
-    var.enable_zscaler_endpoint ? local.zscaler_domain :
-    null
+  private_primary_domain = try(coalesce(local.internal_domain, local.zscaler_domain), null)
+
+  private_subject_alternative_names = compact([
+    (var.enable_internal_endpoint && var.enable_zscaler_endpoint) ? local.zscaler_domain : null,
+  ])
+
+  needs_private_cert = (
+    var.enable_internal_endpoint ||
+    var.enable_zscaler_endpoint ||
+    var.enable_mtls_sidecar
   )
-
-  private_subject_alternative_names = (
-    var.enable_internal_endpoint && var.enable_zscaler_endpoint
-  ) ? [local.zscaler_domain] : []
 }
 
 # -------------------------------------------------------
 # PRIVATE: Issue from AWS Private CA
 # -------------------------------------------------------
 resource "aws_acm_certificate" "private" {
-  count = (var.enable_internal_endpoint || var.enable_zscaler_endpoint) ? 1 : 0
+  count = local.needs_private_cert ? 1 : 0
 
   certificate_authority_arn = one(data.aws_ram_resource_share.pace_ca[0].resource_arns)
   domain_name               = local.private_primary_domain
   subject_alternative_names = local.private_subject_alternative_names
 
-  tags = { Name = "${local.private_primary_domain}-private-cert" }
+  tags = {
+    Name    = "${local.private_primary_domain}-private-cert"
+    MtLS    = tostring(var.enable_mtls_sidecar)
+    Zscaler = tostring(var.enable_zscaler_endpoint)
+  }
 
   lifecycle {
     prevent_destroy       = true

--- a/terraform/modules/acm_certificate/outputs.tf
+++ b/terraform/modules/acm_certificate/outputs.tf
@@ -18,21 +18,22 @@ locals {
   ]) : null
 }
 
-output "private_certificate_arn" {
+output "private_cert_arn" {
   description = "ARN of the PCA-issued certificate covering the internal and/or zscaler domains. Use as the primary cert on the ALB HTTPS listener."
-  value       = (var.enable_internal_endpoint || var.enable_zscaler_endpoint) ? aws_acm_certificate.private[0].arn : null
+  value       = local.needs_private_cert ? aws_acm_certificate.private[0].arn : null
   sensitive   = true
 }
 
 output "internal_domain" {
-  value = var.enable_internal_endpoint ? local.internal_domain : null
+  value       = var.enable_internal_endpoint ? local.internal_domain : null
+  description = "FQDN of the internal endpoint. Use this as the Route 53 record name for DNS record to match exactly."
 }
 
 output "zscaler_domain" {
   value = var.enable_zscaler_endpoint ? local.zscaler_domain : null
 }
 
-output "public_certificate_arn" {
+output "public_cert_arn" {
   description = "ARN of the imported CMS-signed public certificate. Null if cert values have not yet been provided."
   value       = (var.public_domain_name != null && var.public_certificate != null && var.public_private_key != null) ? aws_acm_certificate.public[0].arn : null
   sensitive   = true

--- a/terraform/modules/acm_certificate/variables.tf
+++ b/terraform/modules/acm_certificate/variables.tf
@@ -48,6 +48,21 @@ variable "enable_zscaler_endpoint" {
 }
 
 # -------------------------------------------------------
+# mTLS sidecar
+# -------------------------------------------------------
+
+variable "enable_mtls_sidecar" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+    Issue a PCA-backed certificate for mTLS between the ALB and the sidecar container.
+    This certificate is NOT accessed by developers via Zscaler — it is used internally
+    between the ALB and ECS sidecar only.
+    Domain: <service>.<env>.<app>.internal.cms.gov (same as internal endpoint).
+  EOT
+}
+
+# -------------------------------------------------------
 # Public endpoint (*.cms.gov)
 # -------------------------------------------------------
 

--- a/terraform/modules/datadog_dashboard/main.tf
+++ b/terraform/modules/datadog_dashboard/main.tf
@@ -47,27 +47,30 @@ resource "datadog_dashboard" "application_metrics_dashboard" {
 
         widget {
           manage_status_definition {
-            title               = "Alerting Monitors — ${var.app}"
+            title               = "Alerting Monitors"
             color_preference    = "text"
-            display_format      = "counts"
+            display_format      = "list"
             hide_zero_counts    = true
             show_last_triggered = true
-            sort                = "status,asc"
+            sort                = "triggered,asc"
             summary_type        = "monitors"
-            query               = "tag:\"application:${var.app}\" status:alert"
+
+            # Note that $environment must be unquoted here, because otherwise the * is
+            # treated literally
+            query = "tag:\"application:${var.app}\" tag:$environment status:alert"
           }
         }
 
         widget {
           manage_status_definition {
-            title               = "All Monitors — ${var.app}"
+            title               = "All Monitors"
             color_preference    = "text"
             display_format      = "counts"
             hide_zero_counts    = true
             show_last_triggered = true
             sort                = "status,asc"
             summary_type        = "monitors"
-            query               = "tag:\"application:${var.app}\""
+            query               = "tag:\"application:${var.app}\" tag:$environment"
           }
         }
       }


### PR DESCRIPTION
## 🎫 Ticket
PLT-1720

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Updates the acm_certificate module to account for a new enable_mtls_sidecar option. This change ensures a private cert is also provisioned when the mTLS sidecar is enabled, and ensures that cert is shared for private endpoints, and a public endpoint can also be created. 

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
This module is currently unused, so changes do not risk negative impact. 
This module was tested in the creation of an internal ALB with an ACM cert and a mTLS sidecar, and will be tested in a self signed cert situation. 