### PR TITLE
PLT-1747 Update with ACM permissions

### DIFF
--- a/terraform/services/005-github-actions-role/policy_compute.tf
+++ b/terraform/services/005-github-actions-role/policy_compute.tf
@@ -1,10 +1,40 @@
 data "aws_iam_policy_document" "github_actions_compute" {
   # Certificate Manager
   statement {
+    sid = "AcmRead"
     actions = [
       "acm:DescribeCertificate",
       "acm:GetCertificate",
       "acm:ListCertificates",
+      "acm:ListTagsForCertificate",
+    ]
+    resources = ["*"]
+  }
+
+  # ACM — write operations
+  statement {
+    sid = "AcmWrite"
+    actions = [
+      "acm:AddTagsToCertificate",
+      "acm:DeleteCertificate",
+      "acm:ImportCertificate", # public path for CMS-signed cert
+      "acm:RemoveTagsFromCertificate",
+      "acm:RenewCertificate",
+      "acm:RequestCertificate", # private path for PCA-issued cert
+      "acm:UpdateCertificateOptions",
+    ]
+    resources = ["*"]
+  }
+
+  # ACM Private CA
+  # Needed to describe the shared PCA used for private cert issuance
+  # Actual issuance is handled by ACM internally, no acm-pca:IssueCertificate needed
+  statement {
+    sid = "AcmPcaRead"
+    actions = [
+      "acm-pca:DescribeCertificateAuthority",
+      "acm-pca:GetCertificateAuthorityCertificate",
+      "acm-pca:ListCertificateAuthorities",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## 🎫 Ticket

PLT-1747

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Adds sufficient permissions for teams to leverage ACM certificates and the acm_certificate module. 
## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
These changes were made as the teams were blocked using ACM certificates as things are already configured for them to do so. 

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
These changes were applied for ab2d-test environment github actions role. 