### PR TITLE
BB2-4929 pass enabled value to synthetics module

### DIFF
--- a/terraform/modules/datadog_synthetics/main.tf
+++ b/terraform/modules/datadog_synthetics/main.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "this" {
-  for_each = { for m in var.tests : m.name => m }
+  for_each = { for m in var.tests : m.name => m if var.enabled }
 
   name    = "${var.app}-${var.env}-${each.value.name}"
   type    = each.value.type

--- a/terraform/modules/datadog_synthetics/variables.tf
+++ b/terraform/modules/datadog_synthetics/variables.tf
@@ -24,6 +24,11 @@ variable "min_failure_duration" {
   type        = number
 }
 
+variable "enabled" {
+  description = "Whether synthetics are enabled. If false, nothing will be created. Should be set to the corresponding value from the monitor config passed to the monitors module."
+  type        = bool
+}
+
 variable "tests" {
   description = <<-EOT
     List of synthetic tests to create. Each test is automatically routed through the

--- a/terraform/services/530-cdap-datadog-monitors/synthetics.tf
+++ b/terraform/services/530-cdap-datadog-monitors/synthetics.tf
@@ -5,6 +5,7 @@ module "synthetics" {
   env = var.env
 
   notify               = module.common_datadog_monitors.notify
+  enabled              = local.monitor_config.enabled.synthetics
   shadow_mode          = local.monitor_config.shadow_mode
   min_failure_duration = local.monitor_config.synthetics.min_failure_duration
 


### PR DESCRIPTION

## 🎫 Ticket

BB2-4929

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Pass the monitors config value for `enabled.synthetics` to the synthetics module. This would allow conditional synthetics creation based on environment, for example.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
Before, this was unused.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
