### PR TITLE
PLT-1747 Autoscaling

### DIFF
--- a/terraform/services/005-github-actions-role/config/bcda/dev.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/dev.yml
@@ -4,3 +4,4 @@ additional_kms:
   - "bfd-insights-bcda-dev-event_processor-key"
   - "bfd-insights-bcda-dev-get_job_data-key"
   - "bcda-dev-efs"
+  - "cloudwatch_kms_key"

--- a/terraform/services/005-github-actions-role/config/bcda/dev.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/dev.yml
@@ -4,4 +4,4 @@ additional_kms:
   - "bfd-insights-bcda-dev-event_processor-key"
   - "bfd-insights-bcda-dev-get_job_data-key"
   - "bcda-dev-efs"
-  - "cloudwatch_kms_key"
+  - "bcda-insights-data-sampler-dev-key"

--- a/terraform/services/005-github-actions-role/config/bcda/prod.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/prod.yml
@@ -13,4 +13,5 @@ additional_kms:
   - "bfd-insights-bcda-prod-get_stale_cclf_imports-key"
   - "bcda-prod-access-log-kms"
   - "bfd-insights-bcda-prod-get_num_days_to_make_first_request-key"
+  - "cloudwatch_kms_key"
 

--- a/terraform/services/005-github-actions-role/config/bcda/prod.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/prod.yml
@@ -13,5 +13,4 @@ additional_kms:
   - "bfd-insights-bcda-prod-get_stale_cclf_imports-key"
   - "bcda-prod-access-log-kms"
   - "bfd-insights-bcda-prod-get_num_days_to_make_first_request-key"
-  - "cloudwatch_kms_key"
 

--- a/terraform/services/005-github-actions-role/config/bcda/prod.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/prod.yml
@@ -3,6 +3,7 @@ additional_kms:
   - "bfd-insights-bcda-prod-get_acos_with_expired_credentials-key"
   - "bfd-insights-bcda-prod-event_processor-key"
   - "bfd-insights-bcda-prod-get_num_benes_per_aco-key"
+  - "bcda-insights-data-sampler-prod-key"
   - "bcda-prod-efs"
   - "bcda-prod-rds"
   - "bcda-prod-attribution-import-bucket-key"

--- a/terraform/services/005-github-actions-role/config/bcda/sandbox.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/sandbox.yml
@@ -5,4 +5,5 @@ additional_kms:
   - "bcda-sandbox-rds"
   - "bcda-sandbox-access-log-kms"
   - "bfd-insights-bcda-sandbox-get_job_data-key"
+  - "cloudwatch_kms_key"
 

--- a/terraform/services/005-github-actions-role/config/bcda/sandbox.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/sandbox.yml
@@ -5,5 +5,3 @@ additional_kms:
   - "bcda-sandbox-rds"
   - "bcda-sandbox-access-log-kms"
   - "bfd-insights-bcda-sandbox-get_job_data-key"
-  - "cloudwatch_kms_key"
-

--- a/terraform/services/005-github-actions-role/config/bcda/sandbox.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/sandbox.yml
@@ -1,4 +1,5 @@
 additional_kms:
+  - "bcda-insights-data-sampler-sandbox-key"
   - "bcda-sandbox-app-config-kms"
   - "bcda-sandbox-efs"
   - "bfd-insights-bcda-sandbox-event_processor-key"

--- a/terraform/services/005-github-actions-role/config/bcda/test.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/test.yml
@@ -3,4 +3,3 @@ additional_kms:
   - "bcda-test-aurora-exports-bucket"
   - "bcda-test-attribution-import-bucket-key"
   - "bcda-test-efs"
-  - "cloudwatch_kms_key"

--- a/terraform/services/005-github-actions-role/config/bcda/test.yml
+++ b/terraform/services/005-github-actions-role/config/bcda/test.yml
@@ -3,3 +3,4 @@ additional_kms:
   - "bcda-test-aurora-exports-bucket"
   - "bcda-test-attribution-import-bucket-key"
   - "bcda-test-efs"
+  - "cloudwatch_kms_key"

--- a/terraform/services/005-github-actions-role/policy_compute.tf
+++ b/terraform/services/005-github-actions-role/policy_compute.tf
@@ -46,6 +46,7 @@ data "aws_iam_policy_document" "github_actions_compute" {
       "application-autoscaling:DeleteScalingPolicy",
       "application-autoscaling:DeregisterScalableTarget",
       "application-autoscaling:Describe*",
+      "application-autoscaling:ListTagsForResource",
       "application-autoscaling:PutScalingPolicy",
       "application-autoscaling:RegisterScalableTarget",
       "application-autoscaling:TagResource",

--- a/terraform/services/005-github-actions-role/policy_compute.tf
+++ b/terraform/services/005-github-actions-role/policy_compute.tf
@@ -9,18 +9,19 @@ data "aws_iam_policy_document" "github_actions_compute" {
     resources = ["*"]
   }
 
-  # EC2 Autoscaling
+  # Application Auto Scaling (used by ECS service scaling)
   statement {
+    sid = "ApplicationAutoscaling"
     actions = [
-      "autoscaling:DeleteNotificationConfiguration",
-      "autoscaling:Describe*",
-      "autoscaling:PutNotificationConfiguration",
-      "autoscaling:StartInstanceRefresh",
-      "autoscaling:UpdateAutoScalingGroup",
+      "application-autoscaling:DeleteScalingPolicy",
+      "application-autoscaling:DeregisterScalableTarget",
+      "application-autoscaling:Describe*",
+      "application-autoscaling:PutScalingPolicy",
+      "application-autoscaling:RegisterScalableTarget",
+      "application-autoscaling:TagResource",
     ]
     resources = ["*"]
   }
-
   # CodeBuild
   statement {
     actions = [

--- a/terraform/services/005-github-actions-role/policy_storage.tf
+++ b/terraform/services/005-github-actions-role/policy_storage.tf
@@ -46,6 +46,7 @@ data "aws_iam_policy_document" "github_actions_storage" {
       "rds:CreateDBParameterGroup",
       "rds:CreateDBSubnetGroup",
       "rds:Describe*",
+      "rds:List*",
       "rds:ModifyDBClusterParameterGroup",
       "rds:ModifyDBSubnetGroup",
       "rds:ModifyDBParameterGroup",


### PR DESCRIPTION
## 🎫 Ticket

PLT-1747

## 🛠 Changes
Adds permissions for BCDA for specific KMS keys still used. 
Modifies permissions from EC2 autoscaling features to application autoscaling. 
<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context
These changes were made as BCDA deployments were blocked.

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
These changes were applied for bcda and their deploy scripts successfully passed in Dev. 